### PR TITLE
Fairway: scaffold daemon binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,21 @@
 APP_NAME := shipyard
+FAIRWAY_NAME := shipyard-fairway
 DIST_DIR := dist
 VERSION ?= $(shell cat VERSION)
 COMMIT ?= dev
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -X github.com/shipyard-auto/shipyard/internal/app.Version=$(VERSION) -X github.com/shipyard-auto/shipyard/internal/app.Commit=$(COMMIT) -X github.com/shipyard-auto/shipyard/internal/app.BuildDate=$(BUILD_DATE)
+FAIRWAY_LDFLAGS := -X github.com/shipyard-auto/shipyard/addons/fairway/internal/app.Version=$(VERSION) -X github.com/shipyard-auto/shipyard/addons/fairway/internal/app.Commit=$(COMMIT) -X github.com/shipyard-auto/shipyard/addons/fairway/internal/app.BuildDate=$(BUILD_DATE)
 
-.PHONY: build test fmt tidy clean dist package
+.PHONY: build build-fairway test fmt tidy clean dist package
 
 build:
 	mkdir -p $(DIST_DIR)
 	go build -ldflags "$(LDFLAGS)" -o $(DIST_DIR)/$(APP_NAME) ./cmd/shipyard
+
+build-fairway:
+	mkdir -p $(DIST_DIR)
+	go build -ldflags "$(FAIRWAY_LDFLAGS)" -o $(DIST_DIR)/$(FAIRWAY_NAME) ./addons/fairway/cmd/...
 
 test:
 	go test ./...

--- a/addons/fairway/cmd/main.go
+++ b/addons/fairway/cmd/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	fairwayapp "github.com/shipyard-auto/shipyard/addons/fairway/internal/app"
+)
+
+const stubMessage = "daemon stub — implementado nas tarefas seguintes"
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := flag.NewFlagSet("shipyard-fairway", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var configPath string
+	var showVersion bool
+	var showHelp bool
+
+	fs.StringVar(&configPath, "config", "", "path to config.json")
+	fs.BoolVar(&showVersion, "version", false, "print version and exit")
+	fs.BoolVar(&showHelp, "help", false, "show help and exit")
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, "Usage: %s [flags]\n\n", fs.Name())
+		fmt.Fprintln(stderr, "Flags:")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	_ = configPath
+
+	if showHelp {
+		fs.Usage()
+		return 0
+	}
+
+	if showVersion {
+		_, _ = fmt.Fprintln(stdout, fairwayapp.Info())
+		return 0
+	}
+
+	_, _ = fmt.Fprintln(stdout, stubMessage)
+	return 0
+}

--- a/addons/fairway/internal/app/app.go
+++ b/addons/fairway/internal/app/app.go
@@ -1,0 +1,13 @@
+package app
+
+import "fmt"
+
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func Info() string {
+	return fmt.Sprintf("shipyard-fairway %s (%s, built %s)", Version, Commit, BuildDate)
+}

--- a/addons/fairway/internal/app/app_test.go
+++ b/addons/fairway/internal/app/app_test.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestInfo(t *testing.T) {
+	originalVersion := Version
+	originalCommit := Commit
+	originalBuildDate := BuildDate
+	t.Cleanup(func() {
+		Version = originalVersion
+		Commit = originalCommit
+		BuildDate = originalBuildDate
+	})
+
+	tests := []struct {
+		name      string
+		version   string
+		commit    string
+		buildDate string
+		want      string
+		match     *regexp.Regexp
+	}{
+		{
+			name:      "Info_reportsDefaults",
+			version:   "dev",
+			commit:    "unknown",
+			buildDate: "unknown",
+			want:      "shipyard-fairway dev (unknown, built unknown)",
+		},
+		{
+			name:      "Info_reportsInjectedValues",
+			version:   "9.9.9",
+			commit:    "abc1234",
+			buildDate: "2026-04-16T00:00:00Z",
+			want:      "shipyard-fairway 9.9.9 (abc1234, built 2026-04-16T00:00:00Z)",
+		},
+		{
+			name:      "Info_formatIsStable",
+			version:   "1.2.3",
+			commit:    "deadbeef",
+			buildDate: "2026-04-16",
+			want:      "shipyard-fairway 1.2.3 (deadbeef, built 2026-04-16)",
+			match:     regexp.MustCompile(`^shipyard-fairway \S+ \(\S+, built .+\)$`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Version = tt.version
+			Commit = tt.commit
+			BuildDate = tt.buildDate
+
+			got := Info()
+			if got != tt.want {
+				t.Fatalf("Info() = %q, want %q", got, tt.want)
+			}
+			if tt.match != nil && !tt.match.MatchString(got) {
+				t.Fatalf("Info() = %q, does not match %q", got, tt.match.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add the initial `shipyard-fairway` daemon entrypoint with `--config`, `--help`, and `--version` flags
- add isolated fairway build metadata in `addons/fairway/internal/app` with stable `Info()` formatting and tests
- add `build-fairway` to the Makefile with dedicated ldflags for the addon binary

## Validation
- `gofmt -w addons/fairway/cmd/main.go addons/fairway/internal/app/app.go addons/fairway/internal/app/app_test.go`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/internal/app/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -cover ./addons/fairway/internal/app/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go vet ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache make build-fairway VERSION=9.9.9`
- `GOCACHE=/tmp/shipyard-go-build-cache make build`