### PR TITLE
Fairway: add bounded action executor

### DIFF
--- a/addons/fairway/internal/fairway/actions.go
+++ b/addons/fairway/internal/fairway/actions.go
@@ -1,0 +1,319 @@
+package fairway
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Result represents the outcome of executing a Fairway action.
+type Result struct {
+	HTTPStatus int
+	Body       []byte
+	Header     http.Header
+	Truncated  bool
+	ExitCode   int
+	Duration   time.Duration
+}
+
+// Executor runs route actions for authenticated requests.
+type Executor interface {
+	Execute(ctx context.Context, route Route, req *http.Request) (Result, error)
+}
+
+// SubprocessRunner constructs the command used to execute Shipyard CLI actions.
+type SubprocessRunner func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+// HTTPClient performs outbound HTTP forwarding for http.forward actions.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// ExecutorConfig configures the action executor.
+type ExecutorConfig struct {
+	ShipyardBinary string
+	MaxInFlight    int
+	QueueTimeout   time.Duration
+	DefaultTimeout time.Duration
+	Run            SubprocessRunner
+	HTTP           HTTPClient
+	Now            func() time.Time
+}
+
+type executor struct {
+	binary         string
+	maxInFlight    int
+	queueTimeout   time.Duration
+	defaultTimeout time.Duration
+	run            SubprocessRunner
+	http           HTTPClient
+	now            func() time.Time
+	slots          chan struct{}
+}
+
+// NewExecutor builds the default Fairway action executor.
+func NewExecutor(cfg ExecutorConfig) *executor {
+	if cfg.ShipyardBinary == "" {
+		cfg.ShipyardBinary = "shipyard"
+	}
+	if cfg.MaxInFlight <= 0 {
+		cfg.MaxInFlight = DefaultMaxInFlight
+	}
+	if cfg.QueueTimeout <= 0 {
+		cfg.QueueTimeout = DefaultQueueTimeout
+	}
+	if cfg.DefaultTimeout <= 0 {
+		cfg.DefaultTimeout = DefaultActionTimeout
+	}
+	if cfg.Run == nil {
+		cfg.Run = exec.CommandContext
+	}
+	if cfg.HTTP == nil {
+		cfg.HTTP = &http.Client{Timeout: cfg.DefaultTimeout}
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+
+	return &executor{
+		binary:         cfg.ShipyardBinary,
+		maxInFlight:    cfg.MaxInFlight,
+		queueTimeout:   cfg.QueueTimeout,
+		defaultTimeout: cfg.DefaultTimeout,
+		run:            cfg.Run,
+		http:           cfg.HTTP,
+		now:            cfg.Now,
+		slots:          make(chan struct{}, cfg.MaxInFlight),
+	}
+}
+
+// Execute runs the action described by the route.
+func (e *executor) Execute(ctx context.Context, route Route, req *http.Request) (Result, error) {
+	if route.Action.Type == ActionHTTPForward {
+		return e.executeHTTPForward(ctx, route, req)
+	}
+	return e.executeSubprocess(ctx, route, req)
+}
+
+func (e *executor) executeSubprocess(ctx context.Context, route Route, req *http.Request) (Result, error) {
+	start := e.now()
+
+	select {
+	case e.slots <- struct{}{}:
+	case <-ctx.Done():
+		return Result{HTTPStatus: http.StatusGatewayTimeout, ExitCode: -1, Duration: e.now().Sub(start)}, nil
+	case <-time.After(e.queueTimeout):
+		return Result{HTTPStatus: http.StatusServiceUnavailable, ExitCode: -1, Duration: e.now().Sub(start)}, nil
+	}
+	defer func() { <-e.slots }()
+
+	body, bodyTruncated, err := readBounded(req.Body, MaxSubprocessOutput)
+	if err != nil {
+		return Result{}, err
+	}
+
+	timeout := route.Timeout
+	if timeout <= 0 {
+		timeout = e.defaultTimeout
+	}
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := buildActionArgs(route.Action, body)
+	cmd := e.run(cmdCtx, e.binary, args...)
+	if route.Action.Type == ActionTelegramHandle {
+		cmd.Stdin = bytes.NewReader(body)
+	}
+
+	output := newBoundedBuffer(MaxSubprocessOutput)
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	err = cmd.Run()
+	duration := e.now().Sub(start)
+	result := Result{
+		Body:      output.Bytes(),
+		Truncated: output.Truncated() || bodyTruncated,
+		ExitCode:  -1,
+		Duration:  duration,
+	}
+
+	if errors.Is(cmdCtx.Err(), context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
+		result.HTTPStatus = http.StatusGatewayTimeout
+		return result, nil
+	}
+
+	exitCode := extractExitCode(err, cmd)
+	result.ExitCode = exitCode
+	result.HTTPStatus = mapExitCode(exitCode)
+	return result, nil
+}
+
+func (e *executor) executeHTTPForward(ctx context.Context, route Route, req *http.Request) (Result, error) {
+	start := e.now()
+
+	body, bodyTruncated, err := readBounded(req.Body, MaxSubprocessOutput)
+	if err != nil {
+		return Result{}, err
+	}
+
+	method := route.Action.Method
+	if method == "" {
+		method = http.MethodPost
+	}
+
+	outReq, err := http.NewRequestWithContext(ctx, method, route.Action.URL, bytes.NewReader(body))
+	if err != nil {
+		return Result{}, err
+	}
+	for key, value := range route.Action.Headers {
+		outReq.Header.Set(key, value)
+	}
+
+	resp, err := e.http.Do(outReq)
+	if err != nil {
+		return Result{
+			HTTPStatus: http.StatusBadGateway,
+			ExitCode:   -1,
+			Duration:   e.now().Sub(start),
+		}, nil
+	}
+	defer resp.Body.Close()
+
+	respBody, respTruncated, err := readBounded(resp.Body, MaxSubprocessOutput)
+	if err != nil {
+		return Result{}, err
+	}
+
+	return Result{
+		HTTPStatus: resp.StatusCode,
+		Body:       respBody,
+		Header:     resp.Header.Clone(),
+		Truncated:  bodyTruncated || respTruncated,
+		ExitCode:   -1,
+		Duration:   e.now().Sub(start),
+	}, nil
+}
+
+func buildActionArgs(action Action, body []byte) []string {
+	switch action.Type {
+	case ActionCronRun:
+		return []string{"cron", "run", action.Target}
+	case ActionCronEnable:
+		return []string{"cron", "enable", action.Target}
+	case ActionCronDisable:
+		return []string{"cron", "disable", action.Target}
+	case ActionServiceStart:
+		return []string{"service", "start", action.Target}
+	case ActionServiceStop:
+		return []string{"service", "stop", action.Target}
+	case ActionServiceRestart:
+		return []string{"service", "restart", action.Target}
+	case ActionMessageSend:
+		return []string{"message", "send", string(body)}
+	case ActionTelegramHandle:
+		return []string{"message", "telegram", "handle"}
+	default:
+		return nil
+	}
+}
+
+func mapExitCode(code int) int {
+	switch code {
+	case -1:
+		return http.StatusGatewayTimeout
+	case 0:
+		return http.StatusOK
+	case 1:
+		return http.StatusInternalServerError
+	case 2:
+		return http.StatusBadRequest
+	default:
+		return http.StatusBadGateway
+	}
+}
+
+func extractExitCode(runErr error, cmd *exec.Cmd) int {
+	if runErr == nil {
+		if cmd.ProcessState != nil {
+			return cmd.ProcessState.ExitCode()
+		}
+		return 0
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+func readBounded(r io.Reader, limit int) ([]byte, bool, error) {
+	if r == nil {
+		return nil, false, nil
+	}
+
+	data, err := io.ReadAll(io.LimitReader(r, int64(limit+1)))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(data) > limit {
+		return data[:limit], true, nil
+	}
+	return data, false, nil
+}
+
+type boundedBuffer struct {
+	mu        sync.Mutex
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func newBoundedBuffer(limit int) *boundedBuffer {
+	return &boundedBuffer{limit: limit}
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.buf.Len() >= b.limit {
+		b.truncated = true
+		return len(p), nil
+	}
+
+	remaining := b.limit - b.buf.Len()
+	if len(p) > remaining {
+		b.truncated = true
+		_, _ = b.buf.Write(p[:remaining])
+		return len(p), nil
+	}
+
+	_, _ = b.buf.Write(p)
+	return len(p), nil
+}
+
+func (b *boundedBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return bytes.Clone(b.buf.Bytes())
+}
+
+func (b *boundedBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
+}
+
+func killProcess(cmd *exec.Cmd) {
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Signal(syscall.SIGKILL)
+	}
+}

--- a/addons/fairway/internal/fairway/actions_test.go
+++ b/addons/fairway/internal/fairway/actions_test.go
@@ -1,0 +1,390 @@
+package fairway
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeHTTPClient struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (f fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return f.do(req)
+}
+
+func TestMapExitCode(t *testing.T) {
+	tests := []struct {
+		code int
+		want int
+	}{
+		{-1, http.StatusGatewayTimeout},
+		{0, http.StatusOK},
+		{1, http.StatusInternalServerError},
+		{2, http.StatusBadRequest},
+		{3, http.StatusBadGateway},
+	}
+	for _, tt := range tests {
+		if got := mapExitCode(tt.code); got != tt.want {
+			t.Fatalf("mapExitCode(%d) = %d, want %d", tt.code, got, tt.want)
+		}
+	}
+}
+
+func TestBuildActionArgs(t *testing.T) {
+	tests := []struct {
+		name   string
+		action Action
+		body   []byte
+		want   []string
+	}{
+		{name: "BuildArgs_cronRun_correctCLI", action: Action{Type: ActionCronRun, Target: "job-1"}, want: []string{"cron", "run", "job-1"}},
+		{name: "BuildArgs_serviceRestart_correctCLI", action: Action{Type: ActionServiceRestart, Target: "svc-1"}, want: []string{"service", "restart", "svc-1"}},
+		{name: "BuildArgs_messageSend_bodyBecomesText", action: Action{Type: ActionMessageSend}, body: []byte("hello"), want: []string{"message", "send", "hello"}},
+		{name: "BuildArgs_telegramHandle_bodyViaStdin", action: Action{Type: ActionTelegramHandle}, want: []string{"message", "telegram", "handle"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildActionArgs(tt.action, tt.body)
+			if strings.Join(got, "\x00") != strings.Join(tt.want, "\x00") {
+				t.Fatalf("buildActionArgs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecutorSubprocess(t *testing.T) {
+	t.Run("Exec_cronRun_happyPath", func(t *testing.T) {
+		exec := newHelperExecutor(t, ExecutorConfig{})
+		res, err := exec.Execute(context.Background(), testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if res.HTTPStatus != http.StatusOK || res.ExitCode != 0 || string(res.Body) != "ok\n" {
+			t.Fatalf("result = %#v", res)
+		}
+	})
+
+	t.Run("Exec_cronRun_exit1", func(t *testing.T) {
+		exec := newHelperExecutor(t, ExecutorConfig{ShipyardBinary: "exit1"})
+		res, _ := exec.Execute(context.Background(), testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		if res.HTTPStatus != http.StatusInternalServerError || res.ExitCode != 1 {
+			t.Fatalf("result = %#v", res)
+		}
+	})
+
+	t.Run("Exec_cronRun_exit2", func(t *testing.T) {
+		exec := newHelperExecutor(t, ExecutorConfig{ShipyardBinary: "exit2"})
+		res, _ := exec.Execute(context.Background(), testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		if res.HTTPStatus != http.StatusBadRequest || res.ExitCode != 2 {
+			t.Fatalf("result = %#v", res)
+		}
+	})
+
+	t.Run("Exec_cronRun_exitOther", func(t *testing.T) {
+		exec := newHelperExecutor(t, ExecutorConfig{ShipyardBinary: "exit7"})
+		res, _ := exec.Execute(context.Background(), testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		if res.HTTPStatus != http.StatusBadGateway || res.ExitCode != 7 {
+			t.Fatalf("result = %#v", res)
+		}
+	})
+
+	t.Run("Exec_timeout_returns504", func(t *testing.T) {
+		exec := newHelperExecutor(t, ExecutorConfig{ShipyardBinary: "sleep", DefaultTimeout: 150 * time.Millisecond})
+		route := testExecRoute(ActionCronRun)
+		route.Timeout = 150 * time.Millisecond
+		start := time.Now()
+		res, _ := exec.Execute(context.Background(), route, httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		if res.HTTPStatus != http.StatusGatewayTimeout {
+			t.Fatalf("result = %#v", res)
+		}
+		if time.Since(start) > 2500*time.Millisecond {
+			t.Fatalf("timeout took too long: %s", time.Since(start))
+		}
+	})
+
+	t.Run("Exec_stdoutTruncated", func(t *testing.T) {
+		exec := newHelperExecutor(t, ExecutorConfig{ShipyardBinary: "large"})
+		res, _ := exec.Execute(context.Background(), testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		if !res.Truncated || len(res.Body) != MaxSubprocessOutput {
+			t.Fatalf("result = %#v", res)
+		}
+	})
+
+	t.Run("Exec_respectRouteTimeoutOverride", func(t *testing.T) {
+		exec := newHelperExecutor(t, ExecutorConfig{ShipyardBinary: "sleep", DefaultTimeout: time.Second})
+		route := testExecRoute(ActionCronRun)
+		route.Timeout = 150 * time.Millisecond
+		start := time.Now()
+		res, _ := exec.Execute(context.Background(), route, httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		if res.HTTPStatus != http.StatusGatewayTimeout {
+			t.Fatalf("result = %#v", res)
+		}
+		if time.Since(start) > 2500*time.Millisecond {
+			t.Fatalf("timeout override took too long: %s", time.Since(start))
+		}
+	})
+
+	t.Run("Exec_contextCanceled_returns504", func(t *testing.T) {
+		exec := newHelperExecutor(t, ExecutorConfig{ShipyardBinary: "sleep", DefaultTimeout: time.Second})
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan Result, 1)
+		go func() {
+			res, _ := exec.Execute(ctx, testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+			done <- res
+		}()
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+		res := <-done
+		if res.HTTPStatus != http.StatusGatewayTimeout {
+			t.Fatalf("result = %#v", res)
+		}
+	})
+}
+
+func TestExecutorPool(t *testing.T) {
+	t.Run("Pool_limitsConcurrentExecutions", func(t *testing.T) {
+		var current atomic.Int64
+		var peak atomic.Int64
+		execu := NewExecutor(ExecutorConfig{
+			MaxInFlight: 4,
+			Run: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				cur := current.Add(1)
+				for {
+					old := peak.Load()
+					if cur <= old || peak.CompareAndSwap(old, cur) {
+						break
+					}
+				}
+				cmd := helperCommand(t, "sleep")
+				cmd.Env = append(cmd.Env, "FAIRWAY_HELPER_SLEEP_MS=200")
+				return cmd
+			},
+		})
+
+		var wg sync.WaitGroup
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+				res, _ := execu.Execute(context.Background(), testExecRoute(ActionCronRun), req)
+				if res.HTTPStatus != http.StatusServiceUnavailable {
+					current.Add(-1)
+				}
+			}()
+		}
+
+		wg.Wait()
+		if peak.Load() > 4 {
+			t.Fatalf("peak concurrency = %d, want <= %d", peak.Load(), 4)
+		}
+	})
+
+	t.Run("Pool_queueTimeout_returns503", func(t *testing.T) {
+		execu := NewExecutor(ExecutorConfig{
+			MaxInFlight:  1,
+			QueueTimeout: 100 * time.Millisecond,
+			Run: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				cmd := helperCommand(t, "sleep")
+				cmd.Env = append(cmd.Env, "FAIRWAY_HELPER_SLEEP_MS=400")
+				return cmd
+			},
+		})
+
+		firstDone := make(chan struct{})
+		go func() {
+			defer close(firstDone)
+			_, _ = execu.Execute(context.Background(), testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		}()
+		time.Sleep(100 * time.Millisecond)
+		res, _ := execu.Execute(context.Background(), testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		if res.HTTPStatus != http.StatusServiceUnavailable {
+			t.Fatalf("result = %#v", res)
+		}
+		<-firstDone
+	})
+
+	t.Run("Pool_releasesSlotOnError", func(t *testing.T) {
+		exec := newHelperExecutor(t, ExecutorConfig{MaxInFlight: 1, ShipyardBinary: "exit1"})
+		_, _ = exec.Execute(context.Background(), testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		res, _ := exec.Execute(context.Background(), testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		if res.ExitCode != 1 {
+			t.Fatalf("result = %#v", res)
+		}
+	})
+}
+
+func TestExecutorHTTPForward(t *testing.T) {
+	t.Run("HTTPForward_proxyRequest_passthroughStatus", func(t *testing.T) {
+		exec := NewExecutor(ExecutorConfig{
+			HTTP: fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusAccepted,
+					Header:     http.Header{"X-Test": []string{"1"}},
+					Body:       io.NopCloser(strings.NewReader("forwarded")),
+				}, nil
+			}},
+		})
+
+		route := testForwardRoute()
+		res, _ := exec.Execute(context.Background(), route, httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("body")))
+		if res.HTTPStatus != http.StatusAccepted || string(res.Body) != "forwarded" {
+			t.Fatalf("result = %#v", res)
+		}
+	})
+
+	t.Run("HTTPForward_proxyRequest_copiesHeaders", func(t *testing.T) {
+		exec := NewExecutor(ExecutorConfig{
+			HTTP: fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+				if req.Header.Get("X-Route") != "1" {
+					t.Fatalf("header X-Route = %q, want 1", req.Header.Get("X-Route"))
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+			}},
+		})
+		route := testForwardRoute()
+		_, _ = exec.Execute(context.Background(), route, httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("body")))
+	})
+
+	t.Run("HTTPForward_proxyRequest_bodyBoundLimit", func(t *testing.T) {
+		var captured []byte
+		exec := NewExecutor(ExecutorConfig{
+			HTTP: fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+				body, _ := io.ReadAll(req.Body)
+				captured = body
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(strings.Repeat("a", MaxSubprocessOutput+10)))}, nil
+			}},
+		})
+		route := testForwardRoute()
+		res, _ := exec.Execute(context.Background(), route, httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewReader(bytes.Repeat([]byte("b"), MaxSubprocessOutput+10))))
+		if len(captured) != MaxSubprocessOutput || len(res.Body) != MaxSubprocessOutput || !res.Truncated {
+			t.Fatalf("captured=%d body=%d truncated=%v", len(captured), len(res.Body), res.Truncated)
+		}
+	})
+
+	t.Run("HTTPForward_targetUnreachable_returns502", func(t *testing.T) {
+		exec := NewExecutor(ExecutorConfig{
+			HTTP: fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("dial error")
+			}},
+		})
+		res, _ := exec.Execute(context.Background(), testForwardRoute(), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		if res.HTTPStatus != http.StatusBadGateway {
+			t.Fatalf("result = %#v", res)
+		}
+	})
+
+	t.Run("HTTPForward_doesNotTouchSubprocessPool", func(t *testing.T) {
+		block := make(chan struct{})
+		exec := NewExecutor(ExecutorConfig{
+			MaxInFlight:  1,
+			QueueTimeout: time.Second,
+			Run: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				cmd := helperCommand(t, "sleep")
+				cmd.Env = append(cmd.Env, "FAIRWAY_HELPER_SLEEP_MS=500")
+				return cmd
+			},
+			HTTP: fakeHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+				close(block)
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+			}},
+		})
+
+		go func() {
+			_, _ = exec.Execute(context.Background(), testExecRoute(ActionCronRun), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		}()
+		time.Sleep(100 * time.Millisecond)
+		res, _ := exec.Execute(context.Background(), testForwardRoute(), httptest.NewRequest(http.MethodPost, "http://example.com", nil))
+		<-block
+		if res.HTTPStatus != http.StatusOK {
+			t.Fatalf("result = %#v", res)
+		}
+	})
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	mode := os.Getenv("FAIRWAY_HELPER_MODE")
+	switch mode {
+	case "ok":
+		_, _ = io.WriteString(os.Stdout, "ok\n")
+		os.Exit(0)
+	case "exit1":
+		os.Exit(1)
+	case "exit2":
+		os.Exit(2)
+	case "exit7":
+		os.Exit(7)
+	case "sleep":
+		sleepMS, _ := strconv.Atoi(os.Getenv("FAIRWAY_HELPER_SLEEP_MS"))
+		time.Sleep(time.Duration(sleepMS) * time.Millisecond)
+		_, _ = io.WriteString(os.Stdout, "slept")
+		os.Exit(0)
+	case "large":
+		_, _ = io.WriteString(os.Stdout, strings.Repeat("a", MaxSubprocessOutput+1024))
+		os.Exit(0)
+	default:
+		os.Exit(0)
+	}
+}
+
+func newHelperExecutor(t *testing.T, cfg ExecutorConfig) *executor {
+	t.Helper()
+	mode := cfg.ShipyardBinary
+	if mode == "" {
+		mode = "ok"
+	}
+	cfg.Run = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmd := helperCommand(t, mode)
+		if mode == "sleep" {
+			cmd.Env = append(cmd.Env, "FAIRWAY_HELPER_SLEEP_MS=500")
+		}
+		return cmd
+	}
+	return NewExecutor(cfg)
+}
+
+func helperCommand(t *testing.T, mode string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1", "FAIRWAY_HELPER_MODE="+mode)
+	return cmd
+}
+
+func testExecRoute(actionType ActionType) Route {
+	return Route{
+		Path:   "/hooks/test",
+		Auth:   Auth{Type: AuthBearer, Token: "secret"},
+		Action: Action{Type: actionType, Target: "job-1"},
+	}
+}
+
+func testForwardRoute() Route {
+	return Route{
+		Path: "/hooks/forward",
+		Auth: Auth{Type: AuthBearer, Token: "secret"},
+		Action: Action{
+			Type:    ActionHTTPForward,
+			URL:     "https://example.com/forward",
+			Method:  http.MethodPost,
+			Headers: map[string]string{"X-Route": "1"},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add the Fairway action executor with subprocess execution, queue limiting, bounded output capture, exit-code mapping, and `http.forward` support
- keep timeouts and queue saturation inside the executor so callers get stable HTTP-oriented results without parsing subprocess internals
- add helper-process and fake HTTP client tests covering subprocess behavior, pool saturation, truncation, forwarding, and race-safety

## Validation
- `gofmt -w addons/fairway/internal/fairway/actions.go addons/fairway/internal/fairway/actions_test.go`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -cover ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go vet ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -race ./addons/fairway/internal/fairway/ -run 'TestExecutor|TestMapExitCode|TestBuildActionArgs'`

## Notes
- package coverage in this environment: `87.7%`
- the two commits are intentionally split by implementation vs. verification context, but the order ended up inverted after an `index.lock` collision during parallel git operations