### PR TITLE
Fairway: add HTTP daemon server

### DIFF
--- a/addons/fairway/internal/fairway/server.go
+++ b/addons/fairway/internal/fairway/server.go
@@ -1,0 +1,162 @@
+package fairway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// ServerConfig configures the Fairway HTTP daemon.
+type ServerConfig struct {
+	Router            *Router
+	Executor          Executor
+	ReadHeaderTimeout time.Duration
+	Listen            func(network, address string) (net.Listener, error)
+}
+
+// Server is the Fairway HTTP daemon that authenticates and dispatches inbound requests.
+type Server struct {
+	router   *Router
+	executor Executor
+
+	server *http.Server
+	listen func(network, address string) (net.Listener, error)
+
+	mu       sync.RWMutex
+	listener net.Listener
+	errCh    chan error
+}
+
+// NewServer constructs the Fairway HTTP daemon from the in-memory router config.
+func NewServer(cfg ServerConfig) (*Server, error) {
+	if cfg.Router == nil {
+		return nil, errors.New("router is required")
+	}
+	if cfg.Executor == nil {
+		return nil, errors.New("executor is required")
+	}
+	if cfg.ReadHeaderTimeout <= 0 {
+		cfg.ReadHeaderTimeout = 5 * time.Second
+	}
+	if cfg.Listen == nil {
+		cfg.Listen = net.Listen
+	}
+
+	config := cfg.Router.Config()
+	addr := net.JoinHostPort(config.Bind, fmt.Sprintf("%d", config.Port))
+
+	s := &Server{
+		router:   cfg.Router,
+		executor: cfg.Executor,
+		listen:   cfg.Listen,
+		errCh:    make(chan error, 1),
+	}
+	s.server = &http.Server{
+		Addr:              addr,
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+	}
+	return s, nil
+}
+
+// Handler returns the HTTP handler used by the Fairway daemon.
+func (s *Server) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		route, ok := s.router.Match(r.URL.Path)
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+
+		authenticator, err := NewAuthenticator(route.Auth)
+		if err != nil {
+			http.Error(w, "failed to configure authenticator", http.StatusInternalServerError)
+			return
+		}
+		if err := authenticator.Verify(r); err != nil {
+			if authErr, ok := IsAuth(err); ok {
+				http.Error(w, authErr.Reason, authErr.Status)
+				return
+			}
+			http.Error(w, "authentication failed", http.StatusInternalServerError)
+			return
+		}
+
+		result, err := s.executor.Execute(r.Context(), route, r)
+		if err != nil {
+			http.Error(w, "failed to execute route", http.StatusInternalServerError)
+			return
+		}
+
+		for key, values := range result.Header {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
+
+		status := result.HTTPStatus
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+		if len(result.Body) > 0 && r.Method != http.MethodHead {
+			_, _ = w.Write(result.Body)
+		}
+	})
+}
+
+// Start listens on the configured address and serves requests asynchronously.
+func (s *Server) Start() error {
+	listener, err := s.listen("tcp", s.server.Addr)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.listener = listener
+	s.mu.Unlock()
+
+	go func() {
+		if err := s.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			select {
+			case s.errCh <- err:
+			default:
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Serve serves requests on the provided listener.
+func (s *Server) Serve(listener net.Listener) error {
+	s.mu.Lock()
+	if s.listener == nil {
+		s.listener = listener
+	}
+	s.mu.Unlock()
+	return s.server.Serve(listener)
+}
+
+// Shutdown gracefully stops the HTTP server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
+}
+
+// Addr returns the currently bound listener address, or the configured address before Start.
+func (s *Server) Addr() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.listener != nil {
+		return s.listener.Addr().String()
+	}
+	return s.server.Addr
+}
+
+// Errors returns the asynchronous serve error channel.
+func (s *Server) Errors() <-chan error {
+	return s.errCh
+}

--- a/addons/fairway/internal/fairway/server_test.go
+++ b/addons/fairway/internal/fairway/server_test.go
@@ -1,0 +1,266 @@
+package fairway
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeExecutor struct {
+	execute func(context.Context, Route, *http.Request) (Result, error)
+}
+
+func (f fakeExecutor) Execute(ctx context.Context, route Route, req *http.Request) (Result, error) {
+	return f.execute(ctx, route, req)
+}
+
+func TestNewServer(t *testing.T) {
+	t.Run("rejectsNilRouter", func(t *testing.T) {
+		_, err := NewServer(ServerConfig{Executor: fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
+			return Result{}, nil
+		}}})
+		if err == nil {
+			t.Fatal("NewServer() error = nil, want error")
+		}
+	})
+
+	t.Run("rejectsNilExecutor", func(t *testing.T) {
+		_, err := NewServer(ServerConfig{Router: NewRouterWithConfig(&fakeRepository{}, baseServerConfig())})
+		if err == nil {
+			t.Fatal("NewServer() error = nil, want error")
+		}
+	})
+
+	t.Run("usesRouterBindAndPort", func(t *testing.T) {
+		router := NewRouterWithConfig(&fakeRepository{}, baseServerConfig())
+		srv, err := NewServer(ServerConfig{
+			Router: router,
+			Executor: fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
+				return Result{}, nil
+			}},
+		})
+		if err != nil {
+			t.Fatalf("NewServer() error = %v", err)
+		}
+		if srv.Addr() != net.JoinHostPort(DefaultBind, "0") {
+			t.Fatalf("Addr() = %q, want %q", srv.Addr(), net.JoinHostPort(DefaultBind, "0"))
+		}
+	})
+}
+
+func TestServerHandler(t *testing.T) {
+	t.Run("routeNotFound_returns404", func(t *testing.T) {
+		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
+			return Result{}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/missing", nil)
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("authFailure_returns401", func(t *testing.T) {
+		cfg := baseServerConfig()
+		cfg.Routes = []Route{{
+			Path:   "/hooks/github",
+			Auth:   Auth{Type: AuthBearer, Token: "secret"},
+			Action: Action{Type: ActionCronRun, Target: "job-1"},
+		}}
+		srv := mustNewTestServer(t, cfg, fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
+			t.Fatal("executor should not be called")
+			return Result{}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github", nil)
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("authFailure_returns403", func(t *testing.T) {
+		cfg := baseServerConfig()
+		cfg.Routes = []Route{{
+			Path:   "/internal/events",
+			Auth:   Auth{Type: AuthLocalOnly},
+			Action: Action{Type: ActionCronRun, Target: "job-1"},
+		}}
+		srv := mustNewTestServer(t, cfg, fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
+			t.Fatal("executor should not be called")
+			return Result{}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/internal/events", nil)
+		req.RemoteAddr = "8.8.8.8:12345"
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403", rec.Code)
+		}
+	})
+
+	t.Run("executorResult_passesThroughStatusBodyAndHeaders", func(t *testing.T) {
+		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
+			return Result{
+				HTTPStatus: http.StatusAccepted,
+				Body:       []byte("ok"),
+				Header:     http.Header{"X-Test": []string{"1"}},
+			}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github", nil)
+		req.Header.Set("Authorization", "Bearer secret")
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202", rec.Code)
+		}
+		if rec.Body.String() != "ok" {
+			t.Fatalf("body = %q, want ok", rec.Body.String())
+		}
+		if rec.Header().Get("X-Test") != "1" {
+			t.Fatalf("header X-Test = %q, want 1", rec.Header().Get("X-Test"))
+		}
+	})
+
+	t.Run("executorError_returns500", func(t *testing.T) {
+		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
+			return Result{}, errors.New("boom")
+		}})
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github", nil)
+		req.Header.Set("Authorization", "Bearer secret")
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rec.Code)
+		}
+	})
+
+	t.Run("exactPathOnly_trailingSlashDistinct", func(t *testing.T) {
+		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
+			return Result{}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github/", nil)
+		req.Header.Set("Authorization", "Bearer secret")
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("requestBody_reachesExecutor", func(t *testing.T) {
+		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(_ context.Context, _ Route, req *http.Request) (Result, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error = %v", err)
+			}
+			if string(body) != "payload" {
+				t.Fatalf("body = %q, want payload", string(body))
+			}
+			return Result{HTTPStatus: http.StatusOK}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "http://example.com/hooks/github", strings.NewReader("payload"))
+		req.Header.Set("Authorization", "Bearer secret")
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+	})
+}
+
+func TestServerLifecycle(t *testing.T) {
+	listener := newFakeListener("127.0.0.1:0")
+	router := NewRouterWithConfig(&fakeRepository{}, baseServerConfig())
+	srv, err := NewServer(ServerConfig{
+		Router: router,
+		Executor: fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
+			return Result{HTTPStatus: http.StatusNoContent}, nil
+		}},
+		Listen: func(network, address string) (net.Listener, error) {
+			return listener, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if srv.Addr() != "127.0.0.1:0" {
+		t.Fatalf("Addr() = %q, want 127.0.0.1:0", srv.Addr())
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+}
+
+func mustNewTestServer(t *testing.T, cfg Config, exec fakeExecutor) *Server {
+	t.Helper()
+	router := NewRouterWithConfig(&fakeRepository{}, cfg)
+	srv, err := NewServer(ServerConfig{Router: router, Executor: exec})
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	return srv
+}
+
+func baseServerConfig() Config {
+	return Config{
+		SchemaVersion: SchemaVersion,
+		Port:          0,
+		Bind:          DefaultBind,
+		Routes: []Route{
+			{
+				Path:   "/hooks/github",
+				Auth:   Auth{Type: AuthBearer, Token: "secret"},
+				Action: Action{Type: ActionCronRun, Target: "job-1"},
+			},
+		},
+	}
+}
+
+type fakeListener struct {
+	addr   net.Addr
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newFakeListener(addr string) *fakeListener {
+	return &fakeListener{
+		addr:   fakeAddr(addr),
+		closed: make(chan struct{}),
+	}
+}
+
+func (f *fakeListener) Accept() (net.Conn, error) {
+	<-f.closed
+	return nil, net.ErrClosed
+}
+
+func (f *fakeListener) Close() error {
+	f.once.Do(func() {
+		close(f.closed)
+	})
+	return nil
+}
+
+func (f *fakeListener) Addr() net.Addr {
+	return f.addr
+}
+
+type fakeAddr string
+
+func (f fakeAddr) Network() string { return "tcp" }
+func (f fakeAddr) String() string  { return string(f) }


### PR DESCRIPTION
## Summary
- add the Fairway HTTP daemon with route lookup, per-route authenticator dispatch, executor integration, and graceful shutdown lifecycle
- keep the server lifecycle testable by making the listener injectable while preserving the default bind/port behavior from router config
- add handler tests for 404, auth failures, executor passthrough, request body forwarding, and exact-path matching

## Validation
- `gofmt -w addons/fairway/internal/fairway/server.go addons/fairway/internal/fairway/server_test.go`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -cover ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go vet ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -race ./addons/fairway/internal/fairway/ -run 'TestServer|TestNewServer'`

## Notes
- package coverage in this environment: `88.1%`