### PR TITLE
Fairway: add JSON-RPC socket control plane

### DIFF
--- a/addons/fairway/internal/fairway/socket.go
+++ b/addons/fairway/internal/fairway/socket.go
@@ -1,0 +1,372 @@
+package fairway
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	jsonRPCVersion           = "2.0"
+	defaultHandshakeTimeout  = 2 * time.Second
+	errCodeVersionMismatch   = -32010
+	errCodeHandshakeRequired = -32011
+	errCodeInternal          = -32603
+	errCodeInvalidParams     = -32602
+	errCodeMethodNotFound    = -32601
+	errCodeInvalidRequest    = -32600
+)
+
+// SocketServerConfig configures the Fairway JSON-RPC control plane.
+type SocketServerConfig struct {
+	Router           *Router
+	Version          string
+	HandshakeTimeout time.Duration
+}
+
+// SocketServer serves JSON-RPC 2.0 requests over an NDJSON socket stream.
+type SocketServer struct {
+	router           *Router
+	version          string
+	handshakeTimeout time.Duration
+
+	mu       sync.RWMutex
+	listener net.Listener
+	errCh    chan error
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *rpcError   `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+type handshakeParams struct {
+	Version string `json:"version"`
+}
+
+type routeDeleteParams struct {
+	Path string `json:"path"`
+}
+
+type routeReplaceParams struct {
+	Route Route `json:"route"`
+}
+
+type statusResult struct {
+	Version    string `json:"version"`
+	Bind       string `json:"bind"`
+	Port       int    `json:"port"`
+	RouteCount int    `json:"routeCount"`
+}
+
+// NewSocketServer constructs the Fairway JSON-RPC socket server.
+func NewSocketServer(cfg SocketServerConfig) (*SocketServer, error) {
+	if cfg.Router == nil {
+		return nil, errors.New("router is required")
+	}
+	if cfg.Version == "" {
+		cfg.Version = "dev"
+	}
+	if cfg.HandshakeTimeout <= 0 {
+		cfg.HandshakeTimeout = defaultHandshakeTimeout
+	}
+	return &SocketServer{
+		router:           cfg.Router,
+		version:          cfg.Version,
+		handshakeTimeout: cfg.HandshakeTimeout,
+		errCh:            make(chan error, 1),
+	}, nil
+}
+
+// DefaultSocketPath returns the default Fairway control socket location.
+func DefaultSocketPath() (string, error) {
+	if shipyardHome := os.Getenv("SHIPYARD_HOME"); shipyardHome != "" {
+		return filepath.Join(shipyardHome, "run", "fairway.sock"), nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home dir: %w", err)
+	}
+	return filepath.Join(homeDir, ".shipyard", "run", "fairway.sock"), nil
+}
+
+// Start listens on the provided Unix socket path and serves requests asynchronously.
+func (s *SocketServer) Start(path string) error {
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		return err
+	}
+	_ = os.Chmod(path, 0o600)
+
+	s.mu.Lock()
+	s.listener = listener
+	s.mu.Unlock()
+
+	go func() {
+		if err := s.Serve(listener); err != nil && !errors.Is(err, net.ErrClosed) {
+			select {
+			case s.errCh <- err:
+			default:
+			}
+		}
+	}()
+	return nil
+}
+
+// Serve serves JSON-RPC requests on the provided listener.
+func (s *SocketServer) Serve(listener net.Listener) error {
+	s.mu.Lock()
+	if s.listener == nil {
+		s.listener = listener
+	}
+	s.mu.Unlock()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return err
+		}
+		go s.serveConn(conn)
+	}
+}
+
+// Shutdown closes the listener and stops accepting new connections.
+func (s *SocketServer) Shutdown() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.listener == nil {
+		return nil
+	}
+	return s.listener.Close()
+}
+
+// Errors returns the asynchronous serve error channel.
+func (s *SocketServer) Errors() <-chan error {
+	return s.errCh
+}
+
+func (s *SocketServer) serveConn(conn net.Conn) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	writer := bufio.NewWriter(conn)
+
+	_ = conn.SetReadDeadline(time.Now().Add(s.handshakeTimeout))
+	request, rawLine, err := readRPCRequest(reader)
+	if err != nil {
+		return
+	}
+	if !isHandshakeRequest(request) {
+		_ = writeRPCResponse(writer, rpcResponse{
+			JSONRPC: jsonRPCVersion,
+			ID:      decodeID(rawLine.ID),
+			Error: &rpcError{
+				Code:    errCodeHandshakeRequired,
+				Message: "handshake required",
+			},
+		})
+		return
+	}
+
+	if err := s.handleHandshake(writer, rawLine); err != nil {
+		return
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+
+	for {
+		request, rawLine, err = readRPCRequest(reader)
+		if err != nil {
+			return
+		}
+		response := s.dispatch(rawLine)
+		if err := writeRPCResponse(writer, response); err != nil {
+			return
+		}
+	}
+}
+
+func (s *SocketServer) handleHandshake(writer *bufio.Writer, req rpcRequest) error {
+	var params handshakeParams
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return writeRPCResponse(writer, rpcResponse{
+				JSONRPC: jsonRPCVersion,
+				ID:      decodeID(req.ID),
+				Error: &rpcError{
+					Code:    errCodeInvalidParams,
+					Message: "invalid handshake params",
+				},
+			})
+		}
+	}
+
+	if params.Version != s.version {
+		return writeRPCResponse(writer, rpcResponse{
+			JSONRPC: jsonRPCVersion,
+			ID:      decodeID(req.ID),
+			Error: &rpcError{
+				Code:    errCodeVersionMismatch,
+				Message: "version mismatch",
+				Data: map[string]string{
+					"daemon": s.version,
+					"client": params.Version,
+				},
+			},
+		})
+	}
+
+	return writeRPCResponse(writer, rpcResponse{
+		JSONRPC: jsonRPCVersion,
+		ID:      decodeID(req.ID),
+		Result: map[string]string{
+			"version": s.version,
+		},
+	})
+}
+
+func (s *SocketServer) dispatch(req rpcRequest) rpcResponse {
+	response := rpcResponse{
+		JSONRPC: jsonRPCVersion,
+		ID:      decodeID(req.ID),
+	}
+
+	if req.JSONRPC != "" && req.JSONRPC != jsonRPCVersion {
+		response.Error = &rpcError{Code: errCodeInvalidRequest, Message: "invalid jsonrpc version"}
+		return response
+	}
+
+	switch req.Method {
+	case "route.list":
+		response.Result = s.router.List()
+	case "route.add":
+		var route Route
+		if err := decodeRouteParams(req.Params, &route); err != nil {
+			response.Error = &rpcError{Code: errCodeInvalidParams, Message: "invalid route params"}
+			return response
+		}
+		if err := s.router.Add(route); err != nil {
+			response.Error = &rpcError{Code: errCodeInternal, Message: err.Error()}
+			return response
+		}
+		response.Result = route
+	case "route.delete":
+		var params routeDeleteParams
+		if err := json.Unmarshal(req.Params, &params); err != nil || params.Path == "" {
+			response.Error = &rpcError{Code: errCodeInvalidParams, Message: "invalid route delete params"}
+			return response
+		}
+		if err := s.router.Delete(params.Path); err != nil {
+			response.Error = &rpcError{Code: errCodeInternal, Message: err.Error()}
+			return response
+		}
+		response.Result = map[string]string{"path": params.Path}
+	case "route.replace":
+		var params routeReplaceParams
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			response.Error = &rpcError{Code: errCodeInvalidParams, Message: "invalid route replace params"}
+			return response
+		}
+		if err := s.router.Replace(params.Route); err != nil {
+			response.Error = &rpcError{Code: errCodeInternal, Message: err.Error()}
+			return response
+		}
+		response.Result = params.Route
+	case "status":
+		cfg := s.router.Config()
+		response.Result = statusResult{
+			Version:    s.version,
+			Bind:       cfg.Bind,
+			Port:       cfg.Port,
+			RouteCount: len(cfg.Routes),
+		}
+	default:
+		response.Error = &rpcError{Code: errCodeMethodNotFound, Message: "method not found"}
+	}
+	return response
+}
+
+func readRPCRequest(reader *bufio.Reader) (rpcRequest, rpcRequest, error) {
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		return rpcRequest{}, rpcRequest{}, err
+	}
+	var request rpcRequest
+	if err := json.Unmarshal(bytesTrimSpace(line), &request); err != nil {
+		return rpcRequest{}, rpcRequest{}, err
+	}
+	return request, request, nil
+}
+
+func writeRPCResponse(writer *bufio.Writer, response rpcResponse) error {
+	payload, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+	if _, err := writer.Write(append(payload, '\n')); err != nil {
+		return err
+	}
+	return writer.Flush()
+}
+
+func isHandshakeRequest(req rpcRequest) bool {
+	return req.Method == "handshake"
+}
+
+func decodeRouteParams(raw json.RawMessage, route *Route) error {
+	if len(raw) == 0 {
+		return errors.New("missing params")
+	}
+	if err := json.Unmarshal(raw, route); err == nil && route.Path != "" {
+		return nil
+	}
+	var wrapped routeReplaceParams
+	if err := json.Unmarshal(raw, &wrapped); err != nil {
+		return err
+	}
+	*route = wrapped.Route
+	return nil
+}
+
+func decodeID(raw json.RawMessage) interface{} {
+	if len(raw) == 0 {
+		return nil
+	}
+	var value interface{}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return string(raw)
+	}
+	return value
+}
+
+func bytesTrimSpace(in []byte) []byte {
+	start := 0
+	end := len(in)
+	for start < end && (in[start] == ' ' || in[start] == '\n' || in[start] == '\r' || in[start] == '\t') {
+		start++
+	}
+	for end > start && (in[end-1] == ' ' || in[end-1] == '\n' || in[end-1] == '\r' || in[end-1] == '\t') {
+		end--
+	}
+	return in[start:end]
+}

--- a/addons/fairway/internal/fairway/socket_test.go
+++ b/addons/fairway/internal/fairway/socket_test.go
@@ -1,0 +1,387 @@
+package fairway
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultSocketPath(t *testing.T) {
+	t.Run("respectsShipyardHome", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("SHIPYARD_HOME", root)
+		path, err := DefaultSocketPath()
+		if err != nil {
+			t.Fatalf("DefaultSocketPath() error = %v", err)
+		}
+		want := filepath.Join(root, "run", "fairway.sock")
+		if path != want {
+			t.Fatalf("path = %q, want %q", path, want)
+		}
+	})
+
+	t.Run("fallsBackToHome", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("SHIPYARD_HOME", "")
+		t.Setenv("HOME", root)
+		path, err := DefaultSocketPath()
+		if err != nil {
+			t.Fatalf("DefaultSocketPath() error = %v", err)
+		}
+		want := filepath.Join(root, ".shipyard", "run", "fairway.sock")
+		if path != want {
+			t.Fatalf("path = %q, want %q", path, want)
+		}
+	})
+}
+
+func TestNewSocketServer(t *testing.T) {
+	t.Run("rejectsNilRouter", func(t *testing.T) {
+		_, err := NewSocketServer(SocketServerConfig{})
+		if err == nil {
+			t.Fatal("NewSocketServer() error = nil, want error")
+		}
+	})
+
+	t.Run("fillsDefaults", func(t *testing.T) {
+		server := mustNewSocketServer(t, baseSocketRouterConfig(), "")
+		if server.version != "dev" {
+			t.Fatalf("version = %q, want dev", server.version)
+		}
+		if server.handshakeTimeout != defaultHandshakeTimeout {
+			t.Fatalf("handshakeTimeout = %s, want %s", server.handshakeTimeout, defaultHandshakeTimeout)
+		}
+		if server.Errors() == nil {
+			t.Fatal("Errors() = nil, want channel")
+		}
+	})
+}
+
+func TestSocketServerHandshake(t *testing.T) {
+	server := mustNewSocketServer(t, baseSocketRouterConfig(), "0.22")
+
+	t.Run("requiresHandshakeFirst", func(t *testing.T) {
+		client, conn := net.Pipe()
+		defer client.Close()
+		go server.serveConn(conn)
+
+		writeLine(t, client, `{"jsonrpc":"2.0","id":"1","method":"route.list","params":{}}`)
+		response := readResponse(t, client)
+		if response.Error == nil || response.Error.Code != errCodeHandshakeRequired {
+			t.Fatalf("response = %#v, want handshake required error", response)
+		}
+	})
+
+	t.Run("invalidHandshakeParams", func(t *testing.T) {
+		client, conn := net.Pipe()
+		defer client.Close()
+		go server.serveConn(conn)
+
+		writeLine(t, client, `{"jsonrpc":"2.0","id":"0","method":"handshake","params":"bad"}`)
+		response := readResponse(t, client)
+		if response.Error == nil || response.Error.Code != errCodeInvalidParams {
+			t.Fatalf("response = %#v, want invalid params", response)
+		}
+	})
+
+	t.Run("versionMismatchClosesConnection", func(t *testing.T) {
+		client, conn := net.Pipe()
+		defer client.Close()
+		go server.serveConn(conn)
+
+		writeLine(t, client, `{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.21"}}`)
+		response := readResponse(t, client)
+		if response.Error == nil || response.Error.Code != errCodeVersionMismatch {
+			t.Fatalf("response = %#v, want version mismatch", response)
+		}
+	})
+
+	t.Run("successfulHandshakeAllowsSubsequentCalls", func(t *testing.T) {
+		client, conn := net.Pipe()
+		defer client.Close()
+		go server.serveConn(conn)
+
+		writeLine(t, client, `{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`)
+		handshake := readResponse(t, client)
+		if handshake.Error != nil {
+			t.Fatalf("handshake = %#v, want success", handshake)
+		}
+
+		writeLine(t, client, `{"jsonrpc":"2.0","id":"1","method":"route.list","params":{}}`)
+		response := readResponse(t, client)
+		if response.Error != nil {
+			t.Fatalf("response = %#v, want success", response)
+		}
+	})
+
+	t.Run("handshakeTimeoutClosesConnection", func(t *testing.T) {
+		timeoutServer := mustNewSocketServer(t, baseSocketRouterConfig(), "0.22")
+		timeoutServer.handshakeTimeout = 50 * time.Millisecond
+
+		client, conn := net.Pipe()
+		defer client.Close()
+		go timeoutServer.serveConn(conn)
+
+		time.Sleep(100 * time.Millisecond)
+		if _, err := client.Write([]byte(`{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}` + "\n")); err == nil {
+			t.Fatal("write succeeded after handshake timeout, want closed connection")
+		}
+	})
+}
+
+func TestSocketServerMethods(t *testing.T) {
+	server := mustNewSocketServer(t, baseSocketRouterConfig(), "0.22")
+
+	t.Run("routeList", func(t *testing.T) {
+		response := rpcRoundTrip(t, server,
+			`{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`,
+			`{"jsonrpc":"2.0","id":"1","method":"route.list","params":{}}`,
+		)
+		if response.Error != nil {
+			t.Fatalf("response = %#v, want success", response)
+		}
+		raw, _ := json.Marshal(response.Result)
+		if !strings.Contains(string(raw), `/hooks/github`) {
+			t.Fatalf("result = %s, want /hooks/github", string(raw))
+		}
+	})
+
+	t.Run("routeAddDeleteReplaceAndStatus", func(t *testing.T) {
+		client, conn := net.Pipe()
+		defer client.Close()
+		go server.serveConn(conn)
+
+		writeLine(t, client, `{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`)
+		_ = readResponse(t, client)
+
+		writeLine(t, client, `{"jsonrpc":"2.0","id":"1","method":"route.add","params":{"path":"/hooks/new","auth":{"type":"bearer","token":"secret"},"action":{"type":"cron.run","target":"job-2"}}}`)
+		addResp := readResponse(t, client)
+		if addResp.Error != nil {
+			t.Fatalf("addResp = %#v, want success", addResp)
+		}
+
+		writeLine(t, client, `{"jsonrpc":"2.0","id":"2","method":"status","params":{}}`)
+		statusResp := readResponse(t, client)
+		if statusResp.Error != nil {
+			t.Fatalf("statusResp = %#v, want success", statusResp)
+		}
+		statusRaw, _ := json.Marshal(statusResp.Result)
+		if !strings.Contains(string(statusRaw), `"routeCount":2`) {
+			t.Fatalf("status = %s, want routeCount 2", string(statusRaw))
+		}
+
+		writeLine(t, client, `{"jsonrpc":"2.0","id":"3","method":"route.replace","params":{"route":{"path":"/hooks/new","auth":{"type":"bearer","token":"secret"},"action":{"type":"cron.run","target":"job-3"}}}}`)
+		replaceResp := readResponse(t, client)
+		if replaceResp.Error != nil {
+			t.Fatalf("replaceResp = %#v, want success", replaceResp)
+		}
+
+		writeLine(t, client, `{"jsonrpc":"2.0","id":"4","method":"route.delete","params":{"path":"/hooks/new"}}`)
+		deleteResp := readResponse(t, client)
+		if deleteResp.Error != nil {
+			t.Fatalf("deleteResp = %#v, want success", deleteResp)
+		}
+	})
+
+	t.Run("methodNotFound", func(t *testing.T) {
+		response := rpcRoundTrip(t, server,
+			`{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`,
+			`{"jsonrpc":"2.0","id":"1","method":"unknown.method","params":{}}`,
+		)
+		if response.Error == nil || response.Error.Code != errCodeMethodNotFound {
+			t.Fatalf("response = %#v, want method not found", response)
+		}
+	})
+
+	t.Run("invalidJSONRPCVersion", func(t *testing.T) {
+		response := rpcRoundTrip(t, server,
+			`{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`,
+			`{"jsonrpc":"1.0","id":"1","method":"route.list","params":{}}`,
+		)
+		if response.Error == nil || response.Error.Code != errCodeInvalidRequest {
+			t.Fatalf("response = %#v, want invalid request", response)
+		}
+	})
+
+	t.Run("invalidRouteParams", func(t *testing.T) {
+		response := rpcRoundTrip(t, server,
+			`{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`,
+			`{"jsonrpc":"2.0","id":"1","method":"route.add","params":"bad"}`,
+		)
+		if response.Error == nil || response.Error.Code != errCodeInvalidParams {
+			t.Fatalf("response = %#v, want invalid params", response)
+		}
+	})
+
+	t.Run("invalidDeleteParams", func(t *testing.T) {
+		response := rpcRoundTrip(t, server,
+			`{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`,
+			`{"jsonrpc":"2.0","id":"1","method":"route.delete","params":{}}`,
+		)
+		if response.Error == nil || response.Error.Code != errCodeInvalidParams {
+			t.Fatalf("response = %#v, want invalid params", response)
+		}
+	})
+
+	t.Run("invalidReplaceParams", func(t *testing.T) {
+		response := rpcRoundTrip(t, server,
+			`{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`,
+			`{"jsonrpc":"2.0","id":"1","method":"route.replace","params":"bad"}`,
+		)
+		if response.Error == nil || response.Error.Code != errCodeInvalidParams {
+			t.Fatalf("response = %#v, want invalid params", response)
+		}
+	})
+}
+
+func TestSocketServerStartAndShutdown(t *testing.T) {
+	server := mustNewSocketServer(t, baseSocketRouterConfig(), "0.22")
+	dir, err := os.MkdirTemp("/tmp", "fairway-sock-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "fairway.sock")
+
+	if err := server.Start(socketPath); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer server.Shutdown()
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("socket mode = %o, want 600", got)
+	}
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	defer conn.Close()
+
+	writeLine(t, conn, `{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`)
+	response := readResponse(t, conn)
+	if response.Error != nil {
+		t.Fatalf("response = %#v, want success", response)
+	}
+
+	t.Run("shutdownWithoutListener", func(t *testing.T) {
+		server := mustNewSocketServer(t, baseSocketRouterConfig(), "0.22")
+		if err := server.Shutdown(); err != nil {
+			t.Fatalf("Shutdown() error = %v", err)
+		}
+	})
+}
+
+func TestSocketHelpers(t *testing.T) {
+	t.Run("decodeRouteParamsSupportsWrappedRoute", func(t *testing.T) {
+		var route Route
+		err := decodeRouteParams(json.RawMessage(`{"route":{"path":"/hooks/new","auth":{"type":"bearer","token":"secret"},"action":{"type":"cron.run","target":"job-1"}}}`), &route)
+		if err != nil {
+			t.Fatalf("decodeRouteParams() error = %v", err)
+		}
+		if route.Path != "/hooks/new" {
+			t.Fatalf("route.Path = %q, want /hooks/new", route.Path)
+		}
+	})
+
+	t.Run("decodeRouteParamsMissingParams", func(t *testing.T) {
+		var route Route
+		if err := decodeRouteParams(nil, &route); err == nil {
+			t.Fatal("decodeRouteParams() error = nil, want error")
+		}
+	})
+
+	t.Run("decodeIDFallback", func(t *testing.T) {
+		got := decodeID(json.RawMessage(`{`))
+		if got != "{" {
+			t.Fatalf("decodeID() = %#v, want %q", got, "{")
+		}
+	})
+
+	t.Run("writeRPCResponseMarshalError", func(t *testing.T) {
+		var builder strings.Builder
+		writer := bufio.NewWriter(&builder)
+		err := writeRPCResponse(writer, rpcResponse{
+			JSONRPC: jsonRPCVersion,
+			Result:  make(chan int),
+		})
+		if err == nil {
+			t.Fatal("writeRPCResponse() error = nil, want error")
+		}
+	})
+}
+
+func mustNewSocketServer(t *testing.T, cfg Config, version string) *SocketServer {
+	t.Helper()
+	router := NewRouterWithConfig(&fakeRepository{}, cfg)
+	server, err := NewSocketServer(SocketServerConfig{
+		Router:  router,
+		Version: version,
+	})
+	if err != nil {
+		t.Fatalf("NewSocketServer() error = %v", err)
+	}
+	return server
+}
+
+func baseSocketRouterConfig() Config {
+	return Config{
+		SchemaVersion: SchemaVersion,
+		Port:          DefaultPort,
+		Bind:          DefaultBind,
+		Routes: []Route{
+			{
+				Path:   "/hooks/github",
+				Auth:   Auth{Type: AuthBearer, Token: "secret"},
+				Action: Action{Type: ActionCronRun, Target: "job-1"},
+			},
+		},
+	}
+}
+
+func rpcRoundTrip(t *testing.T, server *SocketServer, lines ...string) rpcResponse {
+	t.Helper()
+	client, conn := net.Pipe()
+	defer client.Close()
+	go server.serveConn(conn)
+
+	var response rpcResponse
+	for i, line := range lines {
+		writeLine(t, client, line)
+		response = readResponse(t, client)
+		if i == 0 && response.Error != nil {
+			t.Fatalf("handshake response = %#v, want success", response)
+		}
+	}
+	return response
+}
+
+func writeLine(t *testing.T, conn net.Conn, line string) {
+	t.Helper()
+	if _, err := conn.Write([]byte(line + "\n")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+}
+
+func readResponse(t *testing.T, conn net.Conn) rpcResponse {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("ReadBytes() error = %v", err)
+	}
+	var response rpcResponse
+	if err := json.Unmarshal(bytesTrimSpace(line), &response); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	return response
+}


### PR DESCRIPTION
## Summary
- add the Fairway Unix socket control plane using NDJSON JSON-RPC 2.0
- enforce version handshake and implement route/status control methods
- cover handshake, method dispatch, socket lifecycle, and race-safe behavior with tests

## Validation
- `gofmt -w addons/fairway/internal/fairway/socket.go addons/fairway/internal/fairway/socket_test.go`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -cover ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go vet ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -race ./addons/fairway/internal/fairway/ -run 'TestSocket|TestNewSocketServer|TestDefaultSocketPath'`