### PR TITLE
Fairway: add pidfile single-instance guard

### DIFF
--- a/addons/fairway/internal/fairway/pidfile.go
+++ b/addons/fairway/internal/fairway/pidfile.go
@@ -1,0 +1,198 @@
+package fairway
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+var ErrAlreadyRunning = errors.New("fairway daemon already running")
+
+// AlreadyRunningError reports that another Fairway daemon instance holds the pidfile lock.
+type AlreadyRunningError struct {
+	Path string
+	PID  int
+}
+
+func (e *AlreadyRunningError) Error() string {
+	if e == nil {
+		return ErrAlreadyRunning.Error()
+	}
+	if e.PID > 0 {
+		return fmt.Sprintf("%s: pid %d", ErrAlreadyRunning.Error(), e.PID)
+	}
+	if e.Path != "" {
+		return fmt.Sprintf("%s: %s", ErrAlreadyRunning.Error(), e.Path)
+	}
+	return ErrAlreadyRunning.Error()
+}
+
+// Unwrap allows errors.Is(err, ErrAlreadyRunning).
+func (e *AlreadyRunningError) Unwrap() error {
+	return ErrAlreadyRunning
+}
+
+// IsAlreadyRunning unwraps ErrAlreadyRunning with typed metadata when available.
+func IsAlreadyRunning(err error) (*AlreadyRunningError, bool) {
+	var runningErr *AlreadyRunningError
+	if errors.As(err, &runningErr) {
+		return runningErr, true
+	}
+	return nil, false
+}
+
+// PIDFile coordinates single-instance Fairway execution through a locked pidfile.
+type PIDFile struct {
+	path string
+
+	mu   sync.Mutex
+	file *os.File
+}
+
+// NewPIDFile returns a pidfile lock for the provided path.
+func NewPIDFile(path string) *PIDFile {
+	if absPath, err := filepath.Abs(path); err == nil {
+		path = absPath
+	}
+	return &PIDFile{path: path}
+}
+
+// DefaultPIDFilePath returns the default Fairway pidfile location.
+func DefaultPIDFilePath() (string, error) {
+	return defaultRuntimePath("fairway.pid")
+}
+
+// Path returns the resolved pidfile path.
+func (p *PIDFile) Path() string {
+	return p.path
+}
+
+// Acquire locks the pidfile, writes the current process ID, and keeps the file open until Release.
+func (p *PIDFile) Acquire() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.file != nil {
+		return nil
+	}
+
+	dir := filepath.Dir(p.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create pid dir %s: %w", dir, err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("chmod pid dir %s: %w", dir, err)
+	}
+
+	file, err := os.OpenFile(p.path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return fmt.Errorf("open pidfile %s: %w", p.path, err)
+	}
+
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		runningErr := &AlreadyRunningError{
+			Path: p.path,
+			PID:  readPID(file),
+		}
+		_ = file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return runningErr
+		}
+		return fmt.Errorf("lock pidfile %s: %w", p.path, err)
+	}
+
+	if err := file.Chmod(0o600); err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+		return fmt.Errorf("chmod pidfile %s: %w", p.path, err)
+	}
+
+	if err := file.Truncate(0); err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+		return fmt.Errorf("truncate pidfile %s: %w", p.path, err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+		return fmt.Errorf("seek pidfile %s: %w", p.path, err)
+	}
+
+	if _, err := fmt.Fprintf(file, "%d\n", os.Getpid()); err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+		return fmt.Errorf("write pidfile %s: %w", p.path, err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+		return fmt.Errorf("sync pidfile %s: %w", p.path, err)
+	}
+
+	p.file = file
+	return nil
+}
+
+// Release unlocks and removes the pidfile.
+func (p *PIDFile) Release() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.file == nil {
+		return nil
+	}
+
+	file := p.file
+	p.file = nil
+
+	unlockErr := syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	closeErr := file.Close()
+	removeErr := os.Remove(p.path)
+	if errors.Is(removeErr, os.ErrNotExist) {
+		removeErr = nil
+	}
+
+	if unlockErr != nil {
+		return fmt.Errorf("unlock pidfile %s: %w", p.path, unlockErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close pidfile %s: %w", p.path, closeErr)
+	}
+	if removeErr != nil {
+		return fmt.Errorf("remove pidfile %s: %w", p.path, removeErr)
+	}
+	return nil
+}
+
+func defaultRuntimePath(name string) (string, error) {
+	if shipyardHome := os.Getenv("SHIPYARD_HOME"); shipyardHome != "" {
+		return filepath.Join(shipyardHome, "run", name), nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home dir: %w", err)
+	}
+	return filepath.Join(homeDir, ".shipyard", "run", name), nil
+}
+
+func readPID(file *os.File) int {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return 0
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
+}

--- a/addons/fairway/internal/fairway/pidfile_test.go
+++ b/addons/fairway/internal/fairway/pidfile_test.go
@@ -1,0 +1,251 @@
+package fairway
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestDefaultPIDFilePath(t *testing.T) {
+	t.Run("UsesShipyardHomeWhenPresent", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("SHIPYARD_HOME", root)
+
+		path, err := DefaultPIDFilePath()
+		if err != nil {
+			t.Fatalf("DefaultPIDFilePath() error = %v", err)
+		}
+
+		want := filepath.Join(root, "run", "fairway.pid")
+		if path != want {
+			t.Fatalf("DefaultPIDFilePath() = %q, want %q", path, want)
+		}
+	})
+
+	t.Run("FallsBackToHomeDir", func(t *testing.T) {
+		t.Setenv("SHIPYARD_HOME", "")
+		root := t.TempDir()
+		t.Setenv("HOME", root)
+
+		path, err := DefaultPIDFilePath()
+		if err != nil {
+			t.Fatalf("DefaultPIDFilePath() error = %v", err)
+		}
+
+		want := filepath.Join(root, ".shipyard", "run", "fairway.pid")
+		if path != want {
+			t.Fatalf("DefaultPIDFilePath() = %q, want %q", path, want)
+		}
+	})
+}
+
+func TestPIDFileAcquireWritesPIDAndReleaseRemovesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run", "fairway.pid")
+	pidfile := NewPIDFile(path)
+
+	if err := pidfile.Acquire(); err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	defer func() {
+		if err := pidfile.Release(); err != nil {
+			t.Fatalf("Release() cleanup error = %v", err)
+		}
+	}()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", path, err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("pidfile mode = %o, want 600", mode)
+	}
+
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", filepath.Dir(path), err)
+	}
+	if mode := dirInfo.Mode().Perm(); mode != 0o700 {
+		t.Fatalf("pid dir mode = %o, want 700", mode)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error = %v", path, err)
+	}
+	if got, want := strings.TrimSpace(string(data)), strconv.Itoa(os.Getpid()); got != want {
+		t.Fatalf("pidfile content = %q, want %q", got, want)
+	}
+
+	if err := pidfile.Release(); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("os.Stat(%q) error = %v, want not exist", path, err)
+	}
+}
+
+func TestPIDFileAcquireReturnsAlreadyRunningError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fairway.pid")
+	cmd, stdin, helperPID := startPIDFileHelper(t, path)
+	defer stopPIDFileHelper(t, cmd, stdin)
+
+	pidfile := NewPIDFile(path)
+	err := pidfile.Acquire()
+	if err == nil {
+		_ = pidfile.Release()
+		t.Fatal("Acquire() error = nil, want already running")
+	}
+
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("errors.Is(err, ErrAlreadyRunning) = false, err = %v", err)
+	}
+
+	runningErr, ok := IsAlreadyRunning(err)
+	if !ok {
+		t.Fatalf("IsAlreadyRunning(%v) = false, want true", err)
+	}
+	if runningErr.PID != helperPID {
+		t.Fatalf("AlreadyRunningError.PID = %d, want %d", runningErr.PID, helperPID)
+	}
+	if runningErr.Path != path {
+		t.Fatalf("AlreadyRunningError.Path = %q, want %q", runningErr.Path, path)
+	}
+}
+
+func TestPIDFileAcquireReusesUnlockedExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fairway.pid")
+	if err := os.WriteFile(path, []byte("999999\n"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(%q) error = %v", path, err)
+	}
+
+	pidfile := NewPIDFile(path)
+	if err := pidfile.Acquire(); err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	defer func() {
+		if err := pidfile.Release(); err != nil {
+			t.Fatalf("Release() cleanup error = %v", err)
+		}
+	}()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error = %v", path, err)
+	}
+	if got, want := strings.TrimSpace(string(data)), strconv.Itoa(os.Getpid()); got != want {
+		t.Fatalf("pidfile content = %q, want %q", got, want)
+	}
+}
+
+func TestPIDFileAcquireIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fairway.pid")
+	pidfile := NewPIDFile(path)
+
+	if err := pidfile.Acquire(); err != nil {
+		t.Fatalf("Acquire() first error = %v", err)
+	}
+	defer func() {
+		if err := pidfile.Release(); err != nil {
+			t.Fatalf("Release() cleanup error = %v", err)
+		}
+	}()
+
+	if err := pidfile.Acquire(); err != nil {
+		t.Fatalf("Acquire() second error = %v", err)
+	}
+}
+
+func TestPIDFileReleaseWithoutAcquire(t *testing.T) {
+	pidfile := NewPIDFile(filepath.Join(t.TempDir(), "fairway.pid"))
+	if err := pidfile.Release(); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+}
+
+func TestHelperPIDFileProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_FAIRWAY_PIDFILE_HELPER") != "1" {
+		return
+	}
+
+	path := os.Getenv("FAIRWAY_PIDFILE_PATH")
+	if path == "" {
+		fmt.Fprintln(os.Stderr, "missing FAIRWAY_PIDFILE_PATH")
+		os.Exit(2)
+	}
+
+	pidfile := NewPIDFile(path)
+	if err := pidfile.Acquire(); err != nil {
+		fmt.Fprintf(os.Stderr, "Acquire() error: %v\n", err)
+		os.Exit(2)
+	}
+	defer func() {
+		_ = pidfile.Release()
+	}()
+
+	fmt.Fprintln(os.Stdout, os.Getpid())
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	os.Exit(0)
+}
+
+func startPIDFileHelper(t *testing.T, path string) (*exec.Cmd, io.WriteCloser, int) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperPIDFileProcess")
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_FAIRWAY_PIDFILE_HELPER=1",
+		"FAIRWAY_PIDFILE_PATH="+path,
+	)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe() error = %v", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("StdinPipe() error = %v", err)
+	}
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	reader := bufio.NewReader(stdout)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("ReadString() error = %v", err)
+	}
+
+	helperPID, err := strconv.Atoi(strings.TrimSpace(line))
+	if err != nil {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("Atoi(%q) error = %v", line, err)
+	}
+
+	return cmd, stdin, helperPID
+}
+
+func stopPIDFileHelper(t *testing.T, cmd *exec.Cmd, stdin io.Closer) {
+	t.Helper()
+	if stdin != nil {
+		_ = stdin.Close()
+	}
+	if cmd == nil {
+		return
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+}

--- a/addons/fairway/internal/fairway/socket.go
+++ b/addons/fairway/internal/fairway/socket.go
@@ -4,10 +4,8 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
 )
@@ -101,14 +99,7 @@ func NewSocketServer(cfg SocketServerConfig) (*SocketServer, error) {
 
 // DefaultSocketPath returns the default Fairway control socket location.
 func DefaultSocketPath() (string, error) {
-	if shipyardHome := os.Getenv("SHIPYARD_HOME"); shipyardHome != "" {
-		return filepath.Join(shipyardHome, "run", "fairway.sock"), nil
-	}
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve user home dir: %w", err)
-	}
-	return filepath.Join(homeDir, ".shipyard", "run", "fairway.sock"), nil
+	return defaultRuntimePath("fairway.sock")
 }
 
 // Start listens on the provided Unix socket path and serves requests asynchronously.


### PR DESCRIPTION
## Summary
- add a Fairway pidfile lock that enforces single-instance daemon startup
- expose a typed already-running error with pid metadata and standard runtime path defaults
- cover pidfile lifecycle, lock contention, cleanup, and race-safe behavior with tests

## Validation
- `gofmt -w addons/fairway/internal/fairway/pidfile.go addons/fairway/internal/fairway/pidfile_test.go addons/fairway/internal/fairway/socket.go`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -cover ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go vet ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -race ./addons/fairway/internal/fairway/ -run 'TestPIDFile|TestDefaultPIDFilePath|TestHelperPIDFileProcess'`