### PR TITLE
Fairway: bootstrap daemon runtime

### DIFF
--- a/addons/fairway/cmd/main.go
+++ b/addons/fairway/cmd/main.go
@@ -1,15 +1,17 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	fairwayapp "github.com/shipyard-auto/shipyard/addons/fairway/internal/app"
+	"github.com/shipyard-auto/shipyard/addons/fairway/internal/fairway"
 )
-
-const stubMessage = "daemon stub — implementado nas tarefas seguintes"
 
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
@@ -20,10 +22,16 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 
 	var configPath string
+	var socketPath string
+	var pidfilePath string
+	var shipyardBinary string
 	var showVersion bool
 	var showHelp bool
 
 	fs.StringVar(&configPath, "config", "", "path to config.json")
+	fs.StringVar(&socketPath, "socket", "", "path to fairway control socket")
+	fs.StringVar(&pidfilePath, "pidfile", "", "path to fairway pidfile")
+	fs.StringVar(&shipyardBinary, "shipyard-bin", "", "path to shipyard binary")
 	fs.BoolVar(&showVersion, "version", false, "print version and exit")
 	fs.BoolVar(&showHelp, "help", false, "show help and exit")
 	fs.Usage = func() {
@@ -36,8 +44,6 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 2
 	}
 
-	_ = configPath
-
 	if showHelp {
 		fs.Usage()
 		return 0
@@ -48,6 +54,25 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 0
 	}
 
-	_, _ = fmt.Fprintln(stdout, stubMessage)
+	daemon, err := fairway.NewDaemon(fairway.BootstrapConfig{
+		ConfigPath:     configPath,
+		SocketPath:     socketPath,
+		PIDFilePath:    pidfilePath,
+		ShipyardBinary: shipyardBinary,
+		Version:        fairwayapp.Version,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "failed to configure fairway daemon: %v\n", err)
+		return 1
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := daemon.Run(ctx); err != nil {
+		_, _ = fmt.Fprintf(stderr, "fairway daemon failed: %v\n", err)
+		return 1
+	}
+
 	return 0
 }

--- a/addons/fairway/internal/fairway/daemon.go
+++ b/addons/fairway/internal/fairway/daemon.go
@@ -1,0 +1,248 @@
+package fairway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const defaultShutdownTimeout = 5 * time.Second
+
+// BootstrapConfig wires the concrete Fairway daemon dependencies from persisted config.
+type BootstrapConfig struct {
+	ConfigPath      string
+	SocketPath      string
+	PIDFilePath     string
+	ShipyardBinary  string
+	Version         string
+	ShutdownTimeout time.Duration
+}
+
+type httpDaemon interface {
+	Start() error
+	Shutdown(context.Context) error
+	Errors() <-chan error
+}
+
+type socketDaemon interface {
+	Start(path string) error
+	Shutdown() error
+	Errors() <-chan error
+}
+
+type pidfileLock interface {
+	Acquire() error
+	Release() error
+	Path() string
+}
+
+// Daemon manages the Fairway HTTP and control-plane servers as a single runtime unit.
+type Daemon struct {
+	http    httpDaemon
+	socket  socketDaemon
+	pidfile pidfileLock
+
+	socketPath      string
+	shutdownTimeout time.Duration
+
+	started bool
+}
+
+// NewDaemon constructs a runnable Fairway daemon from on-disk configuration and defaults.
+func NewDaemon(cfg BootstrapConfig) (*Daemon, error) {
+	configPath := cfg.ConfigPath
+	if configPath == "" {
+		var err error
+		configPath, err = DefaultConfigPath()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	socketPath := cfg.SocketPath
+	if socketPath == "" {
+		var err error
+		socketPath, err = DefaultSocketPath()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	pidfilePath := cfg.PIDFilePath
+	if pidfilePath == "" {
+		var err error
+		pidfilePath, err = DefaultPIDFilePath()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	repo := NewFileRepositoryAt(configPath)
+	router, err := NewRouter(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeConfig := router.Config()
+	executor := NewExecutor(ExecutorConfig{
+		ShipyardBinary: cfg.ShipyardBinary,
+		MaxInFlight:    runtimeConfig.MaxInFlight,
+	})
+
+	httpServer, err := NewServer(ServerConfig{
+		Router:   router,
+		Executor: executor,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	socketServer, err := NewSocketServer(SocketServerConfig{
+		Router:  router,
+		Version: cfg.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return newDaemon(httpServer, socketServer, NewPIDFile(pidfilePath), socketPath, cfg.ShutdownTimeout)
+}
+
+func newDaemon(httpServer httpDaemon, socketServer socketDaemon, pidfile pidfileLock, socketPath string, shutdownTimeout time.Duration) (*Daemon, error) {
+	if httpServer == nil {
+		return nil, errors.New("http server is required")
+	}
+	if socketServer == nil {
+		return nil, errors.New("socket server is required")
+	}
+	if pidfile == nil {
+		return nil, errors.New("pidfile is required")
+	}
+	if socketPath == "" {
+		return nil, errors.New("socket path is required")
+	}
+	if shutdownTimeout <= 0 {
+		shutdownTimeout = defaultShutdownTimeout
+	}
+	return &Daemon{
+		http:            httpServer,
+		socket:          socketServer,
+		pidfile:         pidfile,
+		socketPath:      socketPath,
+		shutdownTimeout: shutdownTimeout,
+	}, nil
+}
+
+// Run starts the daemon, blocks until shutdown, and tears down runtime state cleanly.
+func (d *Daemon) Run(ctx context.Context) error {
+	if err := d.start(); err != nil {
+		return err
+	}
+	defer func() {
+		_ = d.shutdown()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-d.http.Errors():
+		if err == nil || errors.Is(err, net.ErrClosed) {
+			return nil
+		}
+		return err
+	case err := <-d.socket.Errors():
+		if err == nil || errors.Is(err, net.ErrClosed) {
+			return nil
+		}
+		return err
+	}
+}
+
+func (d *Daemon) start() error {
+	if err := d.pidfile.Acquire(); err != nil {
+		return err
+	}
+
+	if err := prepareSocketPath(d.socketPath); err != nil {
+		_ = d.pidfile.Release()
+		return err
+	}
+
+	if err := d.socket.Start(d.socketPath); err != nil {
+		_ = removeSocketPath(d.socketPath)
+		_ = d.pidfile.Release()
+		return err
+	}
+
+	if err := d.http.Start(); err != nil {
+		_ = d.socket.Shutdown()
+		_ = removeSocketPath(d.socketPath)
+		_ = d.pidfile.Release()
+		return err
+	}
+
+	d.started = true
+	return nil
+}
+
+func (d *Daemon) shutdown() error {
+	if !d.started {
+		return nil
+	}
+	d.started = false
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.shutdownTimeout)
+	defer cancel()
+
+	var shutdownErr error
+	if err := d.http.Shutdown(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		shutdownErr = errors.Join(shutdownErr, err)
+	}
+	if err := d.socket.Shutdown(); err != nil && !errors.Is(err, net.ErrClosed) {
+		shutdownErr = errors.Join(shutdownErr, err)
+	}
+	if err := removeSocketPath(d.socketPath); err != nil {
+		shutdownErr = errors.Join(shutdownErr, err)
+	}
+	if err := d.pidfile.Release(); err != nil {
+		shutdownErr = errors.Join(shutdownErr, err)
+	}
+	return shutdownErr
+}
+
+func prepareSocketPath(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create socket dir %s: %w", dir, err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("chmod socket dir %s: %w", dir, err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat socket path %s: %w", path, err)
+	}
+
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("socket path %s exists and is not a socket", path)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove stale socket %s: %w", path, err)
+	}
+	return nil
+}
+
+func removeSocketPath(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove socket path %s: %w", path, err)
+	}
+	return nil
+}

--- a/addons/fairway/internal/fairway/daemon_test.go
+++ b/addons/fairway/internal/fairway/daemon_test.go
@@ -1,0 +1,310 @@
+package fairway
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewDaemon(t *testing.T) {
+	cfg := Config{
+		SchemaVersion: SchemaVersion,
+		Port:          DefaultPort,
+		Bind:          DefaultBind,
+		Routes:        []Route{},
+	}
+
+	t.Run("BuildsDaemonFromDefaults", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("SHIPYARD_HOME", root)
+
+		repo := NewFileRepositoryAt(filepath.Join(root, "fairway", "routes.json"))
+		if err := repo.Save(cfg); err != nil {
+			t.Fatalf("repo.Save() error = %v", err)
+		}
+
+		daemon, err := NewDaemon(BootstrapConfig{Version: "0.22.0"})
+		if err != nil {
+			t.Fatalf("NewDaemon() error = %v", err)
+		}
+		if daemon.socketPath != filepath.Join(root, "run", "fairway.sock") {
+			t.Fatalf("socketPath = %q", daemon.socketPath)
+		}
+		if daemon.pidfile.Path() != filepath.Join(root, "run", "fairway.pid") {
+			t.Fatalf("pidfile path = %q", daemon.pidfile.Path())
+		}
+	})
+
+	t.Run("FailsWhenConfigIsInvalid", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("SHIPYARD_HOME", root)
+
+		repo := NewFileRepositoryAt(filepath.Join(root, "fairway", "routes.json"))
+		if err := os.MkdirAll(filepath.Dir(repo.Path()), 0o700); err != nil {
+			t.Fatalf("os.MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(repo.Path(), []byte(`{"schemaVersion":"999","port":9876,"bind":"127.0.0.1","routes":[]}`), 0o600); err != nil {
+			t.Fatalf("os.WriteFile() error = %v", err)
+		}
+
+		if _, err := NewDaemon(BootstrapConfig{}); err == nil {
+			t.Fatal("NewDaemon() error = nil, want error")
+		}
+	})
+}
+
+func TestDaemonRunLifecycle(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "run", "fairway.sock")
+
+	t.Run("ShutsDownOnContextCancellation", func(t *testing.T) {
+		httpServer := newFakeHTTPDaemon()
+		socketServer := newFakeSocketDaemon()
+		pidfile := &fakePIDFile{path: filepath.Join(t.TempDir(), "fairway.pid")}
+
+		daemon, err := newDaemon(httpServer, socketServer, pidfile, socketPath, 250*time.Millisecond)
+		if err != nil {
+			t.Fatalf("newDaemon() error = %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- daemon.Run(ctx) }()
+
+		httpServer.waitStarted(t)
+		socketServer.waitStarted(t)
+		cancel()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Run() did not return")
+		}
+
+		if !pidfile.acquired || !pidfile.released {
+			t.Fatalf("pidfile lifecycle = acquire %v release %v, want both true", pidfile.acquired, pidfile.released)
+		}
+		if !httpServer.shutdownCalled {
+			t.Fatal("http shutdown not called")
+		}
+		if !socketServer.shutdownCalled {
+			t.Fatal("socket shutdown not called")
+		}
+	})
+
+	t.Run("ReturnsServerErrors", func(t *testing.T) {
+		httpServer := newFakeHTTPDaemon()
+		socketServer := newFakeSocketDaemon()
+		pidfile := &fakePIDFile{path: filepath.Join(t.TempDir(), "fairway.pid")}
+
+		daemon, err := newDaemon(httpServer, socketServer, pidfile, socketPath, time.Second)
+		if err != nil {
+			t.Fatalf("newDaemon() error = %v", err)
+		}
+
+		done := make(chan error, 1)
+		go func() { done <- daemon.Run(context.Background()) }()
+
+		httpServer.waitStarted(t)
+		httpServer.errCh <- errors.New("http serve failed")
+
+		select {
+		case err := <-done:
+			if err == nil || err.Error() != "http serve failed" {
+				t.Fatalf("Run() error = %v, want http serve failed", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Run() did not return")
+		}
+	})
+
+	t.Run("CleansUpWhenHTTPStartFails", func(t *testing.T) {
+		httpServer := newFakeHTTPDaemon()
+		httpServer.startErr = errors.New("bind failed")
+		socketServer := newFakeSocketDaemon()
+		pidfile := &fakePIDFile{path: filepath.Join(t.TempDir(), "fairway.pid")}
+
+		daemon, err := newDaemon(httpServer, socketServer, pidfile, socketPath, time.Second)
+		if err != nil {
+			t.Fatalf("newDaemon() error = %v", err)
+		}
+
+		err = daemon.Run(context.Background())
+		if err == nil || err.Error() != "bind failed" {
+			t.Fatalf("Run() error = %v, want bind failed", err)
+		}
+		if !socketServer.shutdownCalled {
+			t.Fatal("socket shutdown not called after http start failure")
+		}
+		if !pidfile.released {
+			t.Fatal("pidfile not released after http start failure")
+		}
+	})
+}
+
+func TestPrepareSocketPath(t *testing.T) {
+	t.Run("CreatesRuntimeDirectory", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "run", "fairway.sock")
+		if err := prepareSocketPath(path); err != nil {
+			t.Fatalf("prepareSocketPath() error = %v", err)
+		}
+
+		info, err := os.Stat(filepath.Dir(path))
+		if err != nil {
+			t.Fatalf("os.Stat() error = %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o700 {
+			t.Fatalf("dir mode = %o, want 700", got)
+		}
+	})
+
+	t.Run("RemovesStaleSocket", func(t *testing.T) {
+		dir, err := os.MkdirTemp("/tmp", "fairway-daemon-sock-*")
+		if err != nil {
+			t.Fatalf("os.MkdirTemp() error = %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+		path := filepath.Join(dir, "fairway.sock")
+
+		listener, err := net.Listen("unix", path)
+		if err != nil {
+			t.Fatalf("net.Listen() error = %v", err)
+		}
+		listener.Close()
+
+		if err := prepareSocketPath(path); err != nil {
+			t.Fatalf("prepareSocketPath() error = %v", err)
+		}
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("os.Stat(%q) error = %v, want not exist", path, err)
+		}
+	})
+
+	t.Run("RejectsNonSocketFile", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "fairway.sock")
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatalf("os.WriteFile() error = %v", err)
+		}
+
+		if err := prepareSocketPath(path); err == nil {
+			t.Fatal("prepareSocketPath() error = nil, want error")
+		}
+	})
+}
+
+type fakeHTTPDaemon struct {
+	startErr       error
+	shutdownErr    error
+	errCh          chan error
+	started        chan struct{}
+	shutdownCalled bool
+}
+
+func newFakeHTTPDaemon() *fakeHTTPDaemon {
+	return &fakeHTTPDaemon{
+		errCh:   make(chan error, 1),
+		started: make(chan struct{}),
+	}
+}
+
+func (f *fakeHTTPDaemon) Start() error {
+	if f.startErr != nil {
+		return f.startErr
+	}
+	select {
+	case <-f.started:
+	default:
+		close(f.started)
+	}
+	return nil
+}
+
+func (f *fakeHTTPDaemon) Shutdown(context.Context) error {
+	f.shutdownCalled = true
+	return f.shutdownErr
+}
+
+func (f *fakeHTTPDaemon) Errors() <-chan error { return f.errCh }
+
+func (f *fakeHTTPDaemon) waitStarted(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("http daemon did not start")
+	}
+}
+
+type fakeSocketDaemon struct {
+	startErr       error
+	shutdownErr    error
+	errCh          chan error
+	started        chan struct{}
+	shutdownCalled bool
+	startPath      string
+}
+
+func newFakeSocketDaemon() *fakeSocketDaemon {
+	return &fakeSocketDaemon{
+		errCh:   make(chan error, 1),
+		started: make(chan struct{}),
+	}
+}
+
+func (f *fakeSocketDaemon) Start(path string) error {
+	f.startPath = path
+	if f.startErr != nil {
+		return f.startErr
+	}
+	select {
+	case <-f.started:
+	default:
+		close(f.started)
+	}
+	return nil
+}
+
+func (f *fakeSocketDaemon) Shutdown() error {
+	f.shutdownCalled = true
+	return f.shutdownErr
+}
+
+func (f *fakeSocketDaemon) Errors() <-chan error { return f.errCh }
+
+func (f *fakeSocketDaemon) waitStarted(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("socket daemon did not start")
+	}
+}
+
+type fakePIDFile struct {
+	path       string
+	acquireErr error
+	releaseErr error
+	acquired   bool
+	released   bool
+}
+
+func (f *fakePIDFile) Acquire() error {
+	if f.acquireErr != nil {
+		return f.acquireErr
+	}
+	f.acquired = true
+	return nil
+}
+
+func (f *fakePIDFile) Release() error {
+	f.released = true
+	return f.releaseErr
+}
+
+func (f *fakePIDFile) Path() string { return f.path }


### PR DESCRIPTION
## Summary
- replace the Fairway main stub with real daemon bootstrap and signal-driven lifecycle management
- wire persisted config, router, executor, HTTP server, socket control plane, and pidfile guard into a single runtime
- add lifecycle tests for startup, shutdown, error propagation, and stale socket cleanup

## Validation
- `gofmt -w addons/fairway/cmd/main.go addons/fairway/internal/fairway/daemon.go addons/fairway/internal/fairway/daemon_test.go`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -cover ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go vet ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -race ./addons/fairway/internal/fairway/ -run 'TestNewDaemon|TestDaemonRunLifecycle|TestPrepareSocketPath'`
- `make build-fairway VERSION=0.0.0-dev`

## Notes
- `go test ./addons/fairway/...` hit an existing flaky concurrency assertion in `TestExecutorPool` once during parallel validation, then passed on rerun without code changes.