### PR TITLE
Fairway: add runtime status snapshot

### DIFF
--- a/addons/fairway/internal/fairway/daemon.go
+++ b/addons/fairway/internal/fairway/daemon.go
@@ -45,6 +45,7 @@ type Daemon struct {
 	http    httpDaemon
 	socket  socketDaemon
 	pidfile pidfileLock
+	status  *runtimeStatus
 
 	socketPath      string
 	shutdownTimeout time.Duration
@@ -88,6 +89,7 @@ func NewDaemon(cfg BootstrapConfig) (*Daemon, error) {
 	}
 
 	runtimeConfig := router.Config()
+	status := newRuntimeStatus(runtimeConfig, cfg.Version, configPath, socketPath, pidfilePath)
 	executor := NewExecutor(ExecutorConfig{
 		ShipyardBinary: cfg.ShipyardBinary,
 		MaxInFlight:    runtimeConfig.MaxInFlight,
@@ -104,12 +106,18 @@ func NewDaemon(cfg BootstrapConfig) (*Daemon, error) {
 	socketServer, err := NewSocketServer(SocketServerConfig{
 		Router:  router,
 		Version: cfg.Version,
+		Status:  status,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return newDaemon(httpServer, socketServer, NewPIDFile(pidfilePath), socketPath, cfg.ShutdownTimeout)
+	daemon, err := newDaemon(httpServer, socketServer, NewPIDFile(pidfilePath), socketPath, cfg.ShutdownTimeout)
+	if err != nil {
+		return nil, err
+	}
+	daemon.status = status
+	return daemon, nil
 }
 
 func newDaemon(httpServer httpDaemon, socketServer socketDaemon, pidfile pidfileLock, socketPath string, shutdownTimeout time.Duration) (*Daemon, error) {
@@ -186,6 +194,9 @@ func (d *Daemon) start() error {
 	}
 
 	d.started = true
+	if d.status != nil {
+		d.status.MarkStarted(time.Now())
+	}
 	return nil
 }
 
@@ -194,6 +205,9 @@ func (d *Daemon) shutdown() error {
 		return nil
 	}
 	d.started = false
+	if d.status != nil {
+		d.status.MarkStopped()
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.shutdownTimeout)
 	defer cancel()
@@ -212,6 +226,14 @@ func (d *Daemon) shutdown() error {
 		shutdownErr = errors.Join(shutdownErr, err)
 	}
 	return shutdownErr
+}
+
+// Status returns the last known daemon runtime snapshot.
+func (d *Daemon) Status() StatusSnapshot {
+	if d.status == nil {
+		return StatusSnapshot{}
+	}
+	return d.status.Status()
 }
 
 func prepareSocketPath(path string) error {

--- a/addons/fairway/internal/fairway/daemon_test.go
+++ b/addons/fairway/internal/fairway/daemon_test.go
@@ -37,6 +37,13 @@ func TestNewDaemon(t *testing.T) {
 		if daemon.pidfile.Path() != filepath.Join(root, "run", "fairway.pid") {
 			t.Fatalf("pidfile path = %q", daemon.pidfile.Path())
 		}
+		status := daemon.Status()
+		if status.ConfigPath != repo.Path() {
+			t.Fatalf("status.ConfigPath = %q, want %q", status.ConfigPath, repo.Path())
+		}
+		if status.SocketPath != filepath.Join(root, "run", "fairway.sock") {
+			t.Fatalf("status.SocketPath = %q", status.SocketPath)
+		}
 	})
 
 	t.Run("FailsWhenConfigIsInvalid", func(t *testing.T) {
@@ -55,6 +62,39 @@ func TestNewDaemon(t *testing.T) {
 			t.Fatal("NewDaemon() error = nil, want error")
 		}
 	})
+}
+
+func TestRuntimeStatus(t *testing.T) {
+	cfg := Config{
+		SchemaVersion: SchemaVersion,
+		Port:          DefaultPort,
+		Bind:          DefaultBind,
+		Routes: []Route{
+			{Path: "/hooks/a", Auth: Auth{Type: AuthLocalOnly}, Action: Action{Type: ActionMessageSend}},
+			{Path: "/hooks/b", Auth: Auth{Type: AuthLocalOnly}, Action: Action{Type: ActionTelegramHandle}},
+		},
+	}
+
+	status := newRuntimeStatus(cfg, "1.2.3", "/tmp/routes.json", "/tmp/fairway.sock", "/tmp/fairway.pid")
+	snapshot := status.Status()
+	if snapshot.RouteCount != 2 {
+		t.Fatalf("RouteCount = %d, want 2", snapshot.RouteCount)
+	}
+	if snapshot.PID != os.Getpid() {
+		t.Fatalf("PID = %d, want %d", snapshot.PID, os.Getpid())
+	}
+
+	startedAt := time.Date(2026, 4, 17, 1, 45, 0, 0, time.FixedZone("x", -3*3600))
+	status.MarkStarted(startedAt)
+	snapshot = status.Status()
+	if snapshot.StartedAt != startedAt.UTC() {
+		t.Fatalf("StartedAt = %s, want %s", snapshot.StartedAt, startedAt.UTC())
+	}
+
+	status.MarkStopped()
+	if got := status.Status().StartedAt; !got.IsZero() {
+		t.Fatalf("StartedAt after stop = %s, want zero", got)
+	}
 }
 
 func TestDaemonRunLifecycle(t *testing.T) {

--- a/addons/fairway/internal/fairway/socket.go
+++ b/addons/fairway/internal/fairway/socket.go
@@ -26,6 +26,7 @@ type SocketServerConfig struct {
 	Router           *Router
 	Version          string
 	HandshakeTimeout time.Duration
+	Status           statusProvider
 }
 
 // SocketServer serves JSON-RPC 2.0 requests over an NDJSON socket stream.
@@ -33,6 +34,7 @@ type SocketServer struct {
 	router           *Router
 	version          string
 	handshakeTimeout time.Duration
+	status           statusProvider
 
 	mu       sync.RWMutex
 	listener net.Listener
@@ -71,13 +73,6 @@ type routeReplaceParams struct {
 	Route Route `json:"route"`
 }
 
-type statusResult struct {
-	Version    string `json:"version"`
-	Bind       string `json:"bind"`
-	Port       int    `json:"port"`
-	RouteCount int    `json:"routeCount"`
-}
-
 // NewSocketServer constructs the Fairway JSON-RPC socket server.
 func NewSocketServer(cfg SocketServerConfig) (*SocketServer, error) {
 	if cfg.Router == nil {
@@ -93,6 +88,7 @@ func NewSocketServer(cfg SocketServerConfig) (*SocketServer, error) {
 		router:           cfg.Router,
 		version:          cfg.Version,
 		handshakeTimeout: cfg.HandshakeTimeout,
+		status:           cfg.Status,
 		errCh:            make(chan error, 1),
 	}, nil
 }
@@ -284,17 +280,26 @@ func (s *SocketServer) dispatch(req rpcRequest) rpcResponse {
 		}
 		response.Result = params.Route
 	case "status":
-		cfg := s.router.Config()
-		response.Result = statusResult{
-			Version:    s.version,
-			Bind:       cfg.Bind,
-			Port:       cfg.Port,
-			RouteCount: len(cfg.Routes),
-		}
+		response.Result = s.statusSnapshot()
 	default:
 		response.Error = &rpcError{Code: errCodeMethodNotFound, Message: "method not found"}
 	}
 	return response
+}
+
+func (s *SocketServer) statusSnapshot() StatusSnapshot {
+	if s.status != nil {
+		return s.status.Status()
+	}
+
+	cfg := s.router.Config()
+	return StatusSnapshot{
+		Version:    s.version,
+		Bind:       cfg.Bind,
+		Port:       cfg.Port,
+		RouteCount: len(cfg.Routes),
+		PID:        os.Getpid(),
+	}
 }
 
 func readRPCRequest(reader *bufio.Reader) (rpcRequest, rpcRequest, error) {

--- a/addons/fairway/internal/fairway/socket_test.go
+++ b/addons/fairway/internal/fairway/socket_test.go
@@ -174,6 +174,9 @@ func TestSocketServerMethods(t *testing.T) {
 		if !strings.Contains(string(statusRaw), `"routeCount":2`) {
 			t.Fatalf("status = %s, want routeCount 2", string(statusRaw))
 		}
+		if !strings.Contains(string(statusRaw), `"pid":`) {
+			t.Fatalf("status = %s, want pid field", string(statusRaw))
+		}
 
 		writeLine(t, client, `{"jsonrpc":"2.0","id":"3","method":"route.replace","params":{"route":{"path":"/hooks/new","auth":{"type":"bearer","token":"secret"},"action":{"type":"cron.run","target":"job-3"}}}}`)
 		replaceResp := readResponse(t, client)
@@ -235,6 +238,54 @@ func TestSocketServerMethods(t *testing.T) {
 		)
 		if response.Error == nil || response.Error.Code != errCodeInvalidParams {
 			t.Fatalf("response = %#v, want invalid params", response)
+		}
+	})
+
+	t.Run("statusUsesInjectedProvider", func(t *testing.T) {
+		server, err := NewSocketServer(SocketServerConfig{
+			Router:  NewRouterWithConfig(&fakeRepository{}, baseSocketRouterConfig()),
+			Version: "0.22",
+			Status: staticStatusProvider{
+				snapshot: StatusSnapshot{
+					Version:     "9.9.9",
+					Bind:        "127.0.0.2",
+					Port:        4242,
+					RouteCount:  7,
+					PID:         12345,
+					ConfigPath:  "/tmp/routes.json",
+					SocketPath:  "/tmp/fairway.sock",
+					PIDFilePath: "/tmp/fairway.pid",
+					StartedAt:   time.Date(2026, 4, 17, 1, 40, 0, 0, time.UTC),
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewSocketServer() error = %v", err)
+		}
+
+		response := rpcRoundTrip(t, server,
+			`{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`,
+			`{"jsonrpc":"2.0","id":"1","method":"status","params":{}}`,
+		)
+		if response.Error != nil {
+			t.Fatalf("response = %#v, want success", response)
+		}
+
+		raw, _ := json.Marshal(response.Result)
+		text := string(raw)
+		for _, needle := range []string{
+			`"version":"9.9.9"`,
+			`"bind":"127.0.0.2"`,
+			`"port":4242`,
+			`"routeCount":7`,
+			`"pid":12345`,
+			`"configPath":"/tmp/routes.json"`,
+			`"socketPath":"/tmp/fairway.sock"`,
+			`"pidFilePath":"/tmp/fairway.pid"`,
+		} {
+			if !strings.Contains(text, needle) {
+				t.Fatalf("status = %s, want %s", text, needle)
+			}
 		}
 	})
 }
@@ -331,6 +382,14 @@ func mustNewSocketServer(t *testing.T, cfg Config, version string) *SocketServer
 		t.Fatalf("NewSocketServer() error = %v", err)
 	}
 	return server
+}
+
+type staticStatusProvider struct {
+	snapshot StatusSnapshot
+}
+
+func (s staticStatusProvider) Status() StatusSnapshot {
+	return s.snapshot
 }
 
 func baseSocketRouterConfig() Config {

--- a/addons/fairway/internal/fairway/status.go
+++ b/addons/fairway/internal/fairway/status.go
@@ -1,0 +1,79 @@
+package fairway
+
+import (
+	"os"
+	"sync"
+	"time"
+)
+
+// StatusSnapshot describes the current runtime state exposed by the Fairway daemon.
+type StatusSnapshot struct {
+	Version     string    `json:"version"`
+	Bind        string    `json:"bind"`
+	Port        int       `json:"port"`
+	RouteCount  int       `json:"routeCount"`
+	PID         int       `json:"pid"`
+	ConfigPath  string    `json:"configPath,omitempty"`
+	SocketPath  string    `json:"socketPath,omitempty"`
+	PIDFilePath string    `json:"pidFilePath,omitempty"`
+	StartedAt   time.Time `json:"startedAt,omitempty"`
+}
+
+type statusProvider interface {
+	Status() StatusSnapshot
+}
+
+type runtimeStatus struct {
+	mu sync.RWMutex
+
+	version     string
+	bind        string
+	port        int
+	routeCount  int
+	pid         int
+	configPath  string
+	socketPath  string
+	pidfilePath string
+	startedAt   time.Time
+}
+
+func newRuntimeStatus(cfg Config, version, configPath, socketPath, pidfilePath string) *runtimeStatus {
+	return &runtimeStatus{
+		version:     version,
+		bind:        cfg.Bind,
+		port:        cfg.Port,
+		routeCount:  len(cfg.Routes),
+		pid:         os.Getpid(),
+		configPath:  configPath,
+		socketPath:  socketPath,
+		pidfilePath: pidfilePath,
+	}
+}
+
+func (s *runtimeStatus) MarkStarted(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.startedAt = now.UTC()
+}
+
+func (s *runtimeStatus) MarkStopped() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.startedAt = time.Time{}
+}
+
+func (s *runtimeStatus) Status() StatusSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return StatusSnapshot{
+		Version:     s.version,
+		Bind:        s.bind,
+		Port:        s.port,
+		RouteCount:  s.routeCount,
+		PID:         s.pid,
+		ConfigPath:  s.configPath,
+		SocketPath:  s.socketPath,
+		PIDFilePath: s.pidfilePath,
+		StartedAt:   s.startedAt,
+	}
+}


### PR DESCRIPTION
## Summary
- add a runtime status snapshot for the Fairway daemon with pid, runtime paths, and started-at metadata
- inject daemon status into the JSON-RPC socket so `status` reflects live runtime context instead of only static config
- cover daemon and socket status reporting with focused tests

## Validation
- `gofmt -w addons/fairway/internal/fairway/status.go addons/fairway/internal/fairway/socket.go addons/fairway/internal/fairway/socket_test.go addons/fairway/internal/fairway/daemon.go addons/fairway/internal/fairway/daemon_test.go`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -cover ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go vet ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -race ./addons/fairway/internal/fairway/ -run 'TestRuntimeStatus|TestSocketServerMethods|TestNewDaemon|TestDaemonRunLifecycle'`