### PR TITLE
Fairway: add runtime event logging

### DIFF
--- a/addons/fairway/internal/fairway/daemon.go
+++ b/addons/fairway/internal/fairway/daemon.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	yardlogs "github.com/shipyard-auto/shipyard/internal/logs"
 )
 
 const defaultShutdownTimeout = 5 * time.Second
@@ -18,6 +20,7 @@ type BootstrapConfig struct {
 	SocketPath      string
 	PIDFilePath     string
 	ShipyardBinary  string
+	Logger          EventLogger
 	Version         string
 	ShutdownTimeout time.Duration
 }
@@ -46,6 +49,7 @@ type Daemon struct {
 	socket  socketDaemon
 	pidfile pidfileLock
 	status  *runtimeStatus
+	logger  EventLogger
 
 	socketPath      string
 	shutdownTimeout time.Duration
@@ -90,6 +94,14 @@ func NewDaemon(cfg BootstrapConfig) (*Daemon, error) {
 
 	runtimeConfig := router.Config()
 	status := newRuntimeStatus(runtimeConfig, cfg.Version, configPath, socketPath, pidfilePath)
+	logger := cfg.Logger
+	if logger == nil {
+		var err error
+		logger, err = NewLogger()
+		if err != nil {
+			return nil, err
+		}
+	}
 	executor := NewExecutor(ExecutorConfig{
 		ShipyardBinary: cfg.ShipyardBinary,
 		MaxInFlight:    runtimeConfig.MaxInFlight,
@@ -98,6 +110,7 @@ func NewDaemon(cfg BootstrapConfig) (*Daemon, error) {
 	httpServer, err := NewServer(ServerConfig{
 		Router:   router,
 		Executor: executor,
+		Logger:   logger,
 	})
 	if err != nil {
 		return nil, err
@@ -117,6 +130,7 @@ func NewDaemon(cfg BootstrapConfig) (*Daemon, error) {
 		return nil, err
 	}
 	daemon.status = status
+	daemon.logger = logger
 	return daemon, nil
 }
 
@@ -197,6 +211,7 @@ func (d *Daemon) start() error {
 	if d.status != nil {
 		d.status.MarkStarted(time.Now())
 	}
+	d.logEvent("info", "fairway_daemon_started", "Fairway daemon started", nil)
 	return nil
 }
 
@@ -208,6 +223,7 @@ func (d *Daemon) shutdown() error {
 	if d.status != nil {
 		d.status.MarkStopped()
 	}
+	d.logEvent("info", "fairway_daemon_stopped", "Fairway daemon stopped", nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.shutdownTimeout)
 	defer cancel()
@@ -234,6 +250,43 @@ func (d *Daemon) Status() StatusSnapshot {
 		return StatusSnapshot{}
 	}
 	return d.status.Status()
+}
+
+func (d *Daemon) logEvent(level, eventName, message string, data map[string]any) {
+	if d.logger == nil {
+		return
+	}
+
+	snapshot := d.Status()
+	if data == nil {
+		data = map[string]any{}
+	}
+	if snapshot.SocketPath != "" {
+		data["socketPath"] = snapshot.SocketPath
+	}
+	if snapshot.PIDFilePath != "" {
+		data["pidFilePath"] = snapshot.PIDFilePath
+	}
+	if snapshot.ConfigPath != "" {
+		data["configPath"] = snapshot.ConfigPath
+	}
+	if snapshot.Port != 0 {
+		data["port"] = snapshot.Port
+	}
+	if snapshot.Bind != "" {
+		data["bind"] = snapshot.Bind
+	}
+
+	_ = d.logger.Write(yardlogs.Event{
+		Source:     fairwayLogSource,
+		Level:      level,
+		Event:      eventName,
+		Message:    message,
+		EntityType: "daemon",
+		EntityID:   "fairway",
+		EntityName: "fairway",
+		Data:       data,
+	})
 }
 
 func prepareSocketPath(path string) error {

--- a/addons/fairway/internal/fairway/daemon_test.go
+++ b/addons/fairway/internal/fairway/daemon_test.go
@@ -104,11 +104,13 @@ func TestDaemonRunLifecycle(t *testing.T) {
 		httpServer := newFakeHTTPDaemon()
 		socketServer := newFakeSocketDaemon()
 		pidfile := &fakePIDFile{path: filepath.Join(t.TempDir(), "fairway.pid")}
+		logger := &fakeEventLogger{}
 
 		daemon, err := newDaemon(httpServer, socketServer, pidfile, socketPath, 250*time.Millisecond)
 		if err != nil {
 			t.Fatalf("newDaemon() error = %v", err)
 		}
+		daemon.logger = logger
 
 		ctx, cancel := context.WithCancel(context.Background())
 		done := make(chan error, 1)
@@ -135,6 +137,12 @@ func TestDaemonRunLifecycle(t *testing.T) {
 		}
 		if !socketServer.shutdownCalled {
 			t.Fatal("socket shutdown not called")
+		}
+		if got := logger.events[0].Event; got != "fairway_daemon_started" {
+			t.Fatalf("first event = %q, want fairway_daemon_started", got)
+		}
+		if got := logger.events[len(logger.events)-1].Event; got != "fairway_daemon_stopped" {
+			t.Fatalf("last event = %q, want fairway_daemon_stopped", got)
 		}
 	})
 

--- a/addons/fairway/internal/fairway/logging.go
+++ b/addons/fairway/internal/fairway/logging.go
@@ -1,0 +1,45 @@
+package fairway
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	yardlogs "github.com/shipyard-auto/shipyard/internal/logs"
+)
+
+const fairwayLogSource = "fairway"
+
+// EventLogger is the minimal logging boundary used by the Fairway daemon.
+type EventLogger interface {
+	Write(event yardlogs.Event) error
+}
+
+// NewLogger constructs the default Fairway JSONL event logger.
+func NewLogger() (EventLogger, error) {
+	rootDir, err := DefaultLogsRootPath()
+	if err != nil {
+		return nil, err
+	}
+	return yardlogs.Service{
+		RootDir: rootDir,
+		Now:     time.Now,
+	}, nil
+}
+
+// DefaultLogsRootPath returns the log root used by Fairway events.
+func DefaultLogsRootPath() (string, error) {
+	if shipyardHome := os.Getenv("SHIPYARD_HOME"); shipyardHome != "" {
+		return filepath.Join(shipyardHome, "logs"), nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".shipyard", "logs"), nil
+}
+
+type noopLogger struct{}
+
+func (noopLogger) Write(yardlogs.Event) error { return nil }

--- a/addons/fairway/internal/fairway/logging_test.go
+++ b/addons/fairway/internal/fairway/logging_test.go
@@ -1,0 +1,84 @@
+package fairway
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	yardlogs "github.com/shipyard-auto/shipyard/internal/logs"
+)
+
+func TestDefaultLogsRootPath(t *testing.T) {
+	t.Run("usesShipyardHome", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("SHIPYARD_HOME", root)
+
+		path, err := DefaultLogsRootPath()
+		if err != nil {
+			t.Fatalf("DefaultLogsRootPath() error = %v", err)
+		}
+		if want := filepath.Join(root, "logs"); path != want {
+			t.Fatalf("path = %q, want %q", path, want)
+		}
+	})
+
+	t.Run("fallsBackToHome", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("SHIPYARD_HOME", "")
+		t.Setenv("HOME", root)
+
+		path, err := DefaultLogsRootPath()
+		if err != nil {
+			t.Fatalf("DefaultLogsRootPath() error = %v", err)
+		}
+		if want := filepath.Join(root, ".shipyard", "logs"); path != want {
+			t.Fatalf("path = %q, want %q", path, want)
+		}
+	})
+}
+
+func TestNewLoggerWritesFairwayEvents(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("SHIPYARD_HOME", root)
+
+	logger, err := NewLogger()
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+	if err := logger.Write(yardlogs.Event{
+		Source:     fairwayLogSource,
+		Level:      "info",
+		Event:      "fairway_test_event",
+		Message:    "test",
+		EntityType: "daemon",
+		EntityID:   "fairway",
+		EntityName: "fairway",
+	}); err != nil {
+		t.Fatalf("logger.Write() error = %v", err)
+	}
+
+	logDir := filepath.Join(root, "logs", fairwayLogSource)
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		t.Fatalf("os.ReadDir(%q) error = %v", logDir, err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+
+	data, err := os.ReadFile(filepath.Join(logDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	text := string(data)
+	for _, needle := range []string{
+		`"source":"fairway"`,
+		`"event":"fairway_test_event"`,
+		`"entityType":"daemon"`,
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("log file missing %s in %s", needle, text)
+		}
+	}
+}

--- a/addons/fairway/internal/fairway/server.go
+++ b/addons/fairway/internal/fairway/server.go
@@ -8,12 +8,16 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	yardlogs "github.com/shipyard-auto/shipyard/internal/logs"
 )
 
 // ServerConfig configures the Fairway HTTP daemon.
 type ServerConfig struct {
 	Router            *Router
 	Executor          Executor
+	Logger            EventLogger
+	Now               func() time.Time
 	ReadHeaderTimeout time.Duration
 	Listen            func(network, address string) (net.Listener, error)
 }
@@ -22,6 +26,8 @@ type ServerConfig struct {
 type Server struct {
 	router   *Router
 	executor Executor
+	logger   EventLogger
+	now      func() time.Time
 
 	server *http.Server
 	listen func(network, address string) (net.Listener, error)
@@ -42,6 +48,12 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	if cfg.ReadHeaderTimeout <= 0 {
 		cfg.ReadHeaderTimeout = 5 * time.Second
 	}
+	if cfg.Logger == nil {
+		cfg.Logger = noopLogger{}
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
 	if cfg.Listen == nil {
 		cfg.Listen = net.Listen
 	}
@@ -52,6 +64,8 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	s := &Server{
 		router:   cfg.Router,
 		executor: cfg.Executor,
+		logger:   cfg.Logger,
+		now:      cfg.Now,
 		listen:   cfg.Listen,
 		errCh:    make(chan error, 1),
 	}
@@ -66,28 +80,34 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 // Handler returns the HTTP handler used by the Fairway daemon.
 func (s *Server) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := s.now()
 		route, ok := s.router.Match(r.URL.Path)
 		if !ok {
+			s.logRequest("warn", "fairway_route_not_found", "No Fairway route matched the incoming request", Route{}, r, http.StatusNotFound, Result{}, nil, start)
 			http.NotFound(w, r)
 			return
 		}
 
 		authenticator, err := NewAuthenticator(route.Auth)
 		if err != nil {
+			s.logRequest("error", "fairway_auth_config_failed", "Failed to configure Fairway route authenticator", route, r, http.StatusInternalServerError, Result{}, err, start)
 			http.Error(w, "failed to configure authenticator", http.StatusInternalServerError)
 			return
 		}
 		if err := authenticator.Verify(r); err != nil {
 			if authErr, ok := IsAuth(err); ok {
+				s.logRequest("warn", "fairway_auth_failed", "Fairway request authentication failed", route, r, authErr.Status, Result{}, err, start)
 				http.Error(w, authErr.Reason, authErr.Status)
 				return
 			}
+			s.logRequest("error", "fairway_auth_failed", "Fairway request authentication failed", route, r, http.StatusInternalServerError, Result{}, err, start)
 			http.Error(w, "authentication failed", http.StatusInternalServerError)
 			return
 		}
 
 		result, err := s.executor.Execute(r.Context(), route, r)
 		if err != nil {
+			s.logRequest("error", "fairway_action_failed", "Fairway route action execution failed", route, r, http.StatusInternalServerError, Result{}, err, start)
 			http.Error(w, "failed to execute route", http.StatusInternalServerError)
 			return
 		}
@@ -102,10 +122,49 @@ func (s *Server) Handler() http.Handler {
 		if status == 0 {
 			status = http.StatusOK
 		}
+		s.logRequest("info", "fairway_request_handled", "Fairway request handled", route, r, status, result, nil, start)
 		w.WriteHeader(status)
 		if len(result.Body) > 0 && r.Method != http.MethodHead {
 			_, _ = w.Write(result.Body)
 		}
+	})
+}
+
+func (s *Server) logRequest(level, eventName, message string, route Route, req *http.Request, status int, result Result, err error, started time.Time) {
+	if s.logger == nil {
+		return
+	}
+
+	data := map[string]any{
+		"method":     req.Method,
+		"path":       req.URL.Path,
+		"remoteAddr": req.RemoteAddr,
+		"status":     status,
+		"durationMs": s.now().Sub(started).Milliseconds(),
+	}
+	if route.Path != "" {
+		data["routePath"] = route.Path
+		data["actionType"] = route.Action.Type
+	}
+	if result.Truncated {
+		data["truncated"] = true
+	}
+	if result.ExitCode != 0 {
+		data["exitCode"] = result.ExitCode
+	}
+	if err != nil {
+		data["error"] = err.Error()
+	}
+
+	_ = s.logger.Write(yardlogs.Event{
+		Source:     fairwayLogSource,
+		Level:      level,
+		Event:      eventName,
+		Message:    message,
+		EntityType: "route",
+		EntityID:   route.Path,
+		EntityName: route.Path,
+		Data:       data,
 	})
 }
 

--- a/addons/fairway/internal/fairway/server_test.go
+++ b/addons/fairway/internal/fairway/server_test.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	yardlogs "github.com/shipyard-auto/shipyard/internal/logs"
 )
 
 type fakeExecutor struct {
@@ -57,18 +59,23 @@ func TestNewServer(t *testing.T) {
 
 func TestServerHandler(t *testing.T) {
 	t.Run("routeNotFound_returns404", func(t *testing.T) {
+		logger := &fakeEventLogger{}
 		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			return Result{}, nil
-		}})
+		}}, logger)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/missing", nil)
 		srv.Handler().ServeHTTP(rec, req)
 		if rec.Code != http.StatusNotFound {
 			t.Fatalf("status = %d, want 404", rec.Code)
 		}
+		if got := logger.lastEvent().Event; got != "fairway_route_not_found" {
+			t.Fatalf("last event = %q, want fairway_route_not_found", got)
+		}
 	})
 
 	t.Run("authFailure_returns401", func(t *testing.T) {
+		logger := &fakeEventLogger{}
 		cfg := baseServerConfig()
 		cfg.Routes = []Route{{
 			Path:   "/hooks/github",
@@ -78,12 +85,15 @@ func TestServerHandler(t *testing.T) {
 		srv := mustNewTestServer(t, cfg, fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			t.Fatal("executor should not be called")
 			return Result{}, nil
-		}})
+		}}, logger)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github", nil)
 		srv.Handler().ServeHTTP(rec, req)
 		if rec.Code != http.StatusUnauthorized {
 			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+		if got := logger.lastEvent().Event; got != "fairway_auth_failed" {
+			t.Fatalf("last event = %q, want fairway_auth_failed", got)
 		}
 	})
 
@@ -97,7 +107,7 @@ func TestServerHandler(t *testing.T) {
 		srv := mustNewTestServer(t, cfg, fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			t.Fatal("executor should not be called")
 			return Result{}, nil
-		}})
+		}}, &fakeEventLogger{})
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/internal/events", nil)
 		req.RemoteAddr = "8.8.8.8:12345"
@@ -108,13 +118,14 @@ func TestServerHandler(t *testing.T) {
 	})
 
 	t.Run("executorResult_passesThroughStatusBodyAndHeaders", func(t *testing.T) {
+		logger := &fakeEventLogger{}
 		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			return Result{
 				HTTPStatus: http.StatusAccepted,
 				Body:       []byte("ok"),
 				Header:     http.Header{"X-Test": []string{"1"}},
 			}, nil
-		}})
+		}}, logger)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github", nil)
 		req.Header.Set("Authorization", "Bearer secret")
@@ -128,12 +139,20 @@ func TestServerHandler(t *testing.T) {
 		if rec.Header().Get("X-Test") != "1" {
 			t.Fatalf("header X-Test = %q, want 1", rec.Header().Get("X-Test"))
 		}
+		event := logger.lastEvent()
+		if event.Event != "fairway_request_handled" {
+			t.Fatalf("last event = %q, want fairway_request_handled", event.Event)
+		}
+		if got := event.Data["status"]; got != http.StatusAccepted {
+			t.Fatalf("logged status = %#v, want %d", got, http.StatusAccepted)
+		}
 	})
 
 	t.Run("executorError_returns500", func(t *testing.T) {
+		logger := &fakeEventLogger{}
 		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			return Result{}, errors.New("boom")
-		}})
+		}}, logger)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github", nil)
 		req.Header.Set("Authorization", "Bearer secret")
@@ -141,12 +160,15 @@ func TestServerHandler(t *testing.T) {
 		if rec.Code != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want 500", rec.Code)
 		}
+		if got := logger.lastEvent().Event; got != "fairway_action_failed" {
+			t.Fatalf("last event = %q, want fairway_action_failed", got)
+		}
 	})
 
 	t.Run("exactPathOnly_trailingSlashDistinct", func(t *testing.T) {
 		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			return Result{}, nil
-		}})
+		}}, &fakeEventLogger{})
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github/", nil)
 		req.Header.Set("Authorization", "Bearer secret")
@@ -166,7 +188,7 @@ func TestServerHandler(t *testing.T) {
 				t.Fatalf("body = %q, want payload", string(body))
 			}
 			return Result{HTTPStatus: http.StatusOK}, nil
-		}})
+		}}, &fakeEventLogger{})
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "http://example.com/hooks/github", strings.NewReader("payload"))
 		req.Header.Set("Authorization", "Bearer secret")
@@ -206,10 +228,10 @@ func TestServerLifecycle(t *testing.T) {
 	}
 }
 
-func mustNewTestServer(t *testing.T, cfg Config, exec fakeExecutor) *Server {
+func mustNewTestServer(t *testing.T, cfg Config, exec fakeExecutor, logger EventLogger) *Server {
 	t.Helper()
 	router := NewRouterWithConfig(&fakeRepository{}, cfg)
-	srv, err := NewServer(ServerConfig{Router: router, Executor: exec})
+	srv, err := NewServer(ServerConfig{Router: router, Executor: exec, Logger: logger})
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
@@ -258,6 +280,27 @@ func (f *fakeListener) Close() error {
 
 func (f *fakeListener) Addr() net.Addr {
 	return f.addr
+}
+
+type fakeEventLogger struct {
+	mu     sync.Mutex
+	events []yardlogs.Event
+}
+
+func (f *fakeEventLogger) Write(event yardlogs.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, event)
+	return nil
+}
+
+func (f *fakeEventLogger) lastEvent() yardlogs.Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.events) == 0 {
+		return yardlogs.Event{}
+	}
+	return f.events[len(f.events)-1]
 }
 
 type fakeAddr string


### PR DESCRIPTION
## Summary
- add Fairway runtime event logging on top of the existing Shipyard JSONL logs foundation
- instrument daemon lifecycle and HTTP request handling without letting log failures break runtime behavior
- cover default log paths, logger writes, request events, and daemon lifecycle events with tests

## Validation
- `gofmt -w addons/fairway/internal/fairway/logging.go addons/fairway/internal/fairway/logging_test.go addons/fairway/internal/fairway/server.go addons/fairway/internal/fairway/server_test.go addons/fairway/internal/fairway/daemon.go addons/fairway/internal/fairway/daemon_test.go`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -cover ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go vet ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -race ./addons/fairway/internal/fairway/ -run 'TestDefaultLogsRootPath|TestNewLoggerWritesFairwayEvents|TestServerHandler|TestDaemonRunLifecycle'`
- `make build-fairway VERSION=0.0.0-dev`