### PR TITLE
Fairway: add runtime stats snapshot

### DIFF
--- a/addons/fairway/internal/fairway/daemon.go
+++ b/addons/fairway/internal/fairway/daemon.go
@@ -49,6 +49,7 @@ type Daemon struct {
 	socket  socketDaemon
 	pidfile pidfileLock
 	status  *runtimeStatus
+	stats   *runtimeStats
 	logger  EventLogger
 
 	socketPath      string
@@ -94,6 +95,7 @@ func NewDaemon(cfg BootstrapConfig) (*Daemon, error) {
 
 	runtimeConfig := router.Config()
 	status := newRuntimeStatus(runtimeConfig, cfg.Version, configPath, socketPath, pidfilePath)
+	stats := newRuntimeStats()
 	logger := cfg.Logger
 	if logger == nil {
 		var err error
@@ -111,6 +113,7 @@ func NewDaemon(cfg BootstrapConfig) (*Daemon, error) {
 		Router:   router,
 		Executor: executor,
 		Logger:   logger,
+		Stats:    stats,
 	})
 	if err != nil {
 		return nil, err
@@ -120,6 +123,7 @@ func NewDaemon(cfg BootstrapConfig) (*Daemon, error) {
 		Router:  router,
 		Version: cfg.Version,
 		Status:  status,
+		Stats:   stats,
 	})
 	if err != nil {
 		return nil, err
@@ -130,6 +134,7 @@ func NewDaemon(cfg BootstrapConfig) (*Daemon, error) {
 		return nil, err
 	}
 	daemon.status = status
+	daemon.stats = stats
 	daemon.logger = logger
 	return daemon, nil
 }
@@ -250,6 +255,14 @@ func (d *Daemon) Status() StatusSnapshot {
 		return StatusSnapshot{}
 	}
 	return d.status.Status()
+}
+
+// Stats returns the current daemon runtime counters snapshot.
+func (d *Daemon) Stats() StatsSnapshot {
+	if d.stats == nil {
+		return StatsSnapshot{}
+	}
+	return d.stats.Stats()
 }
 
 func (d *Daemon) logEvent(level, eventName, message string, data map[string]any) {

--- a/addons/fairway/internal/fairway/daemon_test.go
+++ b/addons/fairway/internal/fairway/daemon_test.go
@@ -97,6 +97,53 @@ func TestRuntimeStatus(t *testing.T) {
 	}
 }
 
+func TestRuntimeStats(t *testing.T) {
+	stats := newRuntimeStats()
+	now := time.Date(2026, 4, 17, 2, 15, 0, 0, time.UTC)
+
+	stats.Begin(now)
+	stats.RecordHandled(202)
+	stats.End()
+
+	stats.Begin(now.Add(time.Second))
+	stats.RecordRouteNotFound(404)
+	stats.End()
+
+	stats.Begin(now.Add(2 * time.Second))
+	stats.RecordAuthFailure(401)
+	stats.End()
+
+	stats.Begin(now.Add(3 * time.Second))
+	stats.RecordActionFailure(500)
+	stats.End()
+
+	snapshot := stats.Stats()
+	if snapshot.RequestsTotal != 4 {
+		t.Fatalf("RequestsTotal = %d, want 4", snapshot.RequestsTotal)
+	}
+	if snapshot.RequestsHandled != 1 {
+		t.Fatalf("RequestsHandled = %d, want 1", snapshot.RequestsHandled)
+	}
+	if snapshot.RouteNotFound != 1 {
+		t.Fatalf("RouteNotFound = %d, want 1", snapshot.RouteNotFound)
+	}
+	if snapshot.AuthFailures != 1 {
+		t.Fatalf("AuthFailures = %d, want 1", snapshot.AuthFailures)
+	}
+	if snapshot.ActionFailures != 1 {
+		t.Fatalf("ActionFailures = %d, want 1", snapshot.ActionFailures)
+	}
+	if snapshot.ActiveRequests != 0 {
+		t.Fatalf("ActiveRequests = %d, want 0", snapshot.ActiveRequests)
+	}
+	if snapshot.LastRequestAt != now.Add(3*time.Second) {
+		t.Fatalf("LastRequestAt = %s, want %s", snapshot.LastRequestAt, now.Add(3*time.Second))
+	}
+	if snapshot.StatusCodes["202"] != 1 || snapshot.StatusCodes["404"] != 1 || snapshot.StatusCodes["401"] != 1 || snapshot.StatusCodes["500"] != 1 {
+		t.Fatalf("StatusCodes = %#v", snapshot.StatusCodes)
+	}
+}
+
 func TestDaemonRunLifecycle(t *testing.T) {
 	socketPath := filepath.Join(t.TempDir(), "run", "fairway.sock")
 

--- a/addons/fairway/internal/fairway/server.go
+++ b/addons/fairway/internal/fairway/server.go
@@ -17,6 +17,7 @@ type ServerConfig struct {
 	Router            *Router
 	Executor          Executor
 	Logger            EventLogger
+	Stats             *runtimeStats
 	Now               func() time.Time
 	ReadHeaderTimeout time.Duration
 	Listen            func(network, address string) (net.Listener, error)
@@ -27,6 +28,7 @@ type Server struct {
 	router   *Router
 	executor Executor
 	logger   EventLogger
+	stats    *runtimeStats
 	now      func() time.Time
 
 	server *http.Server
@@ -65,6 +67,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		router:   cfg.Router,
 		executor: cfg.Executor,
 		logger:   cfg.Logger,
+		stats:    cfg.Stats,
 		now:      cfg.Now,
 		listen:   cfg.Listen,
 		errCh:    make(chan error, 1),
@@ -81,8 +84,15 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 func (s *Server) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := s.now()
+		if s.stats != nil {
+			s.stats.Begin(start)
+			defer s.stats.End()
+		}
 		route, ok := s.router.Match(r.URL.Path)
 		if !ok {
+			if s.stats != nil {
+				s.stats.RecordRouteNotFound(http.StatusNotFound)
+			}
 			s.logRequest("warn", "fairway_route_not_found", "No Fairway route matched the incoming request", Route{}, r, http.StatusNotFound, Result{}, nil, start)
 			http.NotFound(w, r)
 			return
@@ -90,15 +100,24 @@ func (s *Server) Handler() http.Handler {
 
 		authenticator, err := NewAuthenticator(route.Auth)
 		if err != nil {
+			if s.stats != nil {
+				s.stats.RecordActionFailure(http.StatusInternalServerError)
+			}
 			s.logRequest("error", "fairway_auth_config_failed", "Failed to configure Fairway route authenticator", route, r, http.StatusInternalServerError, Result{}, err, start)
 			http.Error(w, "failed to configure authenticator", http.StatusInternalServerError)
 			return
 		}
 		if err := authenticator.Verify(r); err != nil {
 			if authErr, ok := IsAuth(err); ok {
+				if s.stats != nil {
+					s.stats.RecordAuthFailure(authErr.Status)
+				}
 				s.logRequest("warn", "fairway_auth_failed", "Fairway request authentication failed", route, r, authErr.Status, Result{}, err, start)
 				http.Error(w, authErr.Reason, authErr.Status)
 				return
+			}
+			if s.stats != nil {
+				s.stats.RecordAuthFailure(http.StatusInternalServerError)
 			}
 			s.logRequest("error", "fairway_auth_failed", "Fairway request authentication failed", route, r, http.StatusInternalServerError, Result{}, err, start)
 			http.Error(w, "authentication failed", http.StatusInternalServerError)
@@ -107,6 +126,9 @@ func (s *Server) Handler() http.Handler {
 
 		result, err := s.executor.Execute(r.Context(), route, r)
 		if err != nil {
+			if s.stats != nil {
+				s.stats.RecordActionFailure(http.StatusInternalServerError)
+			}
 			s.logRequest("error", "fairway_action_failed", "Fairway route action execution failed", route, r, http.StatusInternalServerError, Result{}, err, start)
 			http.Error(w, "failed to execute route", http.StatusInternalServerError)
 			return
@@ -121,6 +143,9 @@ func (s *Server) Handler() http.Handler {
 		status := result.HTTPStatus
 		if status == 0 {
 			status = http.StatusOK
+		}
+		if s.stats != nil {
+			s.stats.RecordHandled(status)
 		}
 		s.logRequest("info", "fairway_request_handled", "Fairway request handled", route, r, status, result, nil, start)
 		w.WriteHeader(status)

--- a/addons/fairway/internal/fairway/server_test.go
+++ b/addons/fairway/internal/fairway/server_test.go
@@ -60,9 +60,10 @@ func TestNewServer(t *testing.T) {
 func TestServerHandler(t *testing.T) {
 	t.Run("routeNotFound_returns404", func(t *testing.T) {
 		logger := &fakeEventLogger{}
+		stats := newRuntimeStats()
 		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			return Result{}, nil
-		}}, logger)
+		}}, logger, stats)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/missing", nil)
 		srv.Handler().ServeHTTP(rec, req)
@@ -72,10 +73,14 @@ func TestServerHandler(t *testing.T) {
 		if got := logger.lastEvent().Event; got != "fairway_route_not_found" {
 			t.Fatalf("last event = %q, want fairway_route_not_found", got)
 		}
+		if got := stats.Stats().RouteNotFound; got != 1 {
+			t.Fatalf("RouteNotFound = %d, want 1", got)
+		}
 	})
 
 	t.Run("authFailure_returns401", func(t *testing.T) {
 		logger := &fakeEventLogger{}
+		stats := newRuntimeStats()
 		cfg := baseServerConfig()
 		cfg.Routes = []Route{{
 			Path:   "/hooks/github",
@@ -85,7 +90,7 @@ func TestServerHandler(t *testing.T) {
 		srv := mustNewTestServer(t, cfg, fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			t.Fatal("executor should not be called")
 			return Result{}, nil
-		}}, logger)
+		}}, logger, stats)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github", nil)
 		srv.Handler().ServeHTTP(rec, req)
@@ -94,6 +99,9 @@ func TestServerHandler(t *testing.T) {
 		}
 		if got := logger.lastEvent().Event; got != "fairway_auth_failed" {
 			t.Fatalf("last event = %q, want fairway_auth_failed", got)
+		}
+		if got := stats.Stats().AuthFailures; got != 1 {
+			t.Fatalf("AuthFailures = %d, want 1", got)
 		}
 	})
 
@@ -107,7 +115,7 @@ func TestServerHandler(t *testing.T) {
 		srv := mustNewTestServer(t, cfg, fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			t.Fatal("executor should not be called")
 			return Result{}, nil
-		}}, &fakeEventLogger{})
+		}}, &fakeEventLogger{}, newRuntimeStats())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/internal/events", nil)
 		req.RemoteAddr = "8.8.8.8:12345"
@@ -119,13 +127,14 @@ func TestServerHandler(t *testing.T) {
 
 	t.Run("executorResult_passesThroughStatusBodyAndHeaders", func(t *testing.T) {
 		logger := &fakeEventLogger{}
+		stats := newRuntimeStats()
 		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			return Result{
 				HTTPStatus: http.StatusAccepted,
 				Body:       []byte("ok"),
 				Header:     http.Header{"X-Test": []string{"1"}},
 			}, nil
-		}}, logger)
+		}}, logger, stats)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github", nil)
 		req.Header.Set("Authorization", "Bearer secret")
@@ -146,13 +155,21 @@ func TestServerHandler(t *testing.T) {
 		if got := event.Data["status"]; got != http.StatusAccepted {
 			t.Fatalf("logged status = %#v, want %d", got, http.StatusAccepted)
 		}
+		snapshot := stats.Stats()
+		if snapshot.RequestsHandled != 1 {
+			t.Fatalf("RequestsHandled = %d, want 1", snapshot.RequestsHandled)
+		}
+		if got := snapshot.StatusCodes["202"]; got != 1 {
+			t.Fatalf("StatusCodes[202] = %d, want 1", got)
+		}
 	})
 
 	t.Run("executorError_returns500", func(t *testing.T) {
 		logger := &fakeEventLogger{}
+		stats := newRuntimeStats()
 		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			return Result{}, errors.New("boom")
-		}}, logger)
+		}}, logger, stats)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github", nil)
 		req.Header.Set("Authorization", "Bearer secret")
@@ -163,12 +180,15 @@ func TestServerHandler(t *testing.T) {
 		if got := logger.lastEvent().Event; got != "fairway_action_failed" {
 			t.Fatalf("last event = %q, want fairway_action_failed", got)
 		}
+		if got := stats.Stats().ActionFailures; got != 1 {
+			t.Fatalf("ActionFailures = %d, want 1", got)
+		}
 	})
 
 	t.Run("exactPathOnly_trailingSlashDistinct", func(t *testing.T) {
 		srv := mustNewTestServer(t, baseServerConfig(), fakeExecutor{execute: func(context.Context, Route, *http.Request) (Result, error) {
 			return Result{}, nil
-		}}, &fakeEventLogger{})
+		}}, &fakeEventLogger{}, newRuntimeStats())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/hooks/github/", nil)
 		req.Header.Set("Authorization", "Bearer secret")
@@ -188,7 +208,7 @@ func TestServerHandler(t *testing.T) {
 				t.Fatalf("body = %q, want payload", string(body))
 			}
 			return Result{HTTPStatus: http.StatusOK}, nil
-		}}, &fakeEventLogger{})
+		}}, &fakeEventLogger{}, newRuntimeStats())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "http://example.com/hooks/github", strings.NewReader("payload"))
 		req.Header.Set("Authorization", "Bearer secret")
@@ -228,10 +248,10 @@ func TestServerLifecycle(t *testing.T) {
 	}
 }
 
-func mustNewTestServer(t *testing.T, cfg Config, exec fakeExecutor, logger EventLogger) *Server {
+func mustNewTestServer(t *testing.T, cfg Config, exec fakeExecutor, logger EventLogger, stats *runtimeStats) *Server {
 	t.Helper()
 	router := NewRouterWithConfig(&fakeRepository{}, cfg)
-	srv, err := NewServer(ServerConfig{Router: router, Executor: exec, Logger: logger})
+	srv, err := NewServer(ServerConfig{Router: router, Executor: exec, Logger: logger, Stats: stats})
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}

--- a/addons/fairway/internal/fairway/socket.go
+++ b/addons/fairway/internal/fairway/socket.go
@@ -27,6 +27,7 @@ type SocketServerConfig struct {
 	Version          string
 	HandshakeTimeout time.Duration
 	Status           statusProvider
+	Stats            statsProvider
 }
 
 // SocketServer serves JSON-RPC 2.0 requests over an NDJSON socket stream.
@@ -35,6 +36,7 @@ type SocketServer struct {
 	version          string
 	handshakeTimeout time.Duration
 	status           statusProvider
+	stats            statsProvider
 
 	mu       sync.RWMutex
 	listener net.Listener
@@ -89,6 +91,7 @@ func NewSocketServer(cfg SocketServerConfig) (*SocketServer, error) {
 		version:          cfg.Version,
 		handshakeTimeout: cfg.HandshakeTimeout,
 		status:           cfg.Status,
+		stats:            cfg.Stats,
 		errCh:            make(chan error, 1),
 	}, nil
 }
@@ -281,6 +284,8 @@ func (s *SocketServer) dispatch(req rpcRequest) rpcResponse {
 		response.Result = params.Route
 	case "status":
 		response.Result = s.statusSnapshot()
+	case "stats":
+		response.Result = s.statsSnapshot()
 	default:
 		response.Error = &rpcError{Code: errCodeMethodNotFound, Message: "method not found"}
 	}
@@ -300,6 +305,13 @@ func (s *SocketServer) statusSnapshot() StatusSnapshot {
 		RouteCount: len(cfg.Routes),
 		PID:        os.Getpid(),
 	}
+}
+
+func (s *SocketServer) statsSnapshot() StatsSnapshot {
+	if s.stats != nil {
+		return s.stats.Stats()
+	}
+	return StatsSnapshot{}
 }
 
 func readRPCRequest(reader *bufio.Reader) (rpcRequest, rpcRequest, error) {

--- a/addons/fairway/internal/fairway/socket_test.go
+++ b/addons/fairway/internal/fairway/socket_test.go
@@ -288,6 +288,56 @@ func TestSocketServerMethods(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("statsUsesInjectedProvider", func(t *testing.T) {
+		server, err := NewSocketServer(SocketServerConfig{
+			Router:  NewRouterWithConfig(&fakeRepository{}, baseSocketRouterConfig()),
+			Version: "0.22",
+			Stats: staticStatsProvider{
+				snapshot: StatsSnapshot{
+					RequestsTotal:   12,
+					RequestsHandled: 9,
+					RouteNotFound:   1,
+					AuthFailures:    1,
+					ActionFailures:  1,
+					ActiveRequests:  2,
+					LastRequestAt:   time.Date(2026, 4, 17, 2, 12, 0, 0, time.UTC),
+					StatusCodes: map[string]int64{
+						"200": 8,
+						"404": 1,
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewSocketServer() error = %v", err)
+		}
+
+		response := rpcRoundTrip(t, server,
+			`{"jsonrpc":"2.0","id":"0","method":"handshake","params":{"version":"0.22"}}`,
+			`{"jsonrpc":"2.0","id":"1","method":"stats","params":{}}`,
+		)
+		if response.Error != nil {
+			t.Fatalf("response = %#v, want success", response)
+		}
+
+		raw, _ := json.Marshal(response.Result)
+		text := string(raw)
+		for _, needle := range []string{
+			`"requestsTotal":12`,
+			`"requestsHandled":9`,
+			`"routeNotFound":1`,
+			`"authFailures":1`,
+			`"actionFailures":1`,
+			`"activeRequests":2`,
+			`"200":8`,
+			`"404":1`,
+		} {
+			if !strings.Contains(text, needle) {
+				t.Fatalf("stats = %s, want %s", text, needle)
+			}
+		}
+	})
 }
 
 func TestSocketServerStartAndShutdown(t *testing.T) {
@@ -389,6 +439,14 @@ type staticStatusProvider struct {
 }
 
 func (s staticStatusProvider) Status() StatusSnapshot {
+	return s.snapshot
+}
+
+type staticStatsProvider struct {
+	snapshot StatsSnapshot
+}
+
+func (s staticStatsProvider) Stats() StatsSnapshot {
 	return s.snapshot
 }
 

--- a/addons/fairway/internal/fairway/stats.go
+++ b/addons/fairway/internal/fairway/stats.go
@@ -1,0 +1,105 @@
+package fairway
+
+import (
+	"strconv"
+	"sync"
+	"time"
+)
+
+// StatsSnapshot describes in-memory runtime counters for the Fairway daemon.
+type StatsSnapshot struct {
+	RequestsTotal   int64            `json:"requestsTotal"`
+	RequestsHandled int64            `json:"requestsHandled"`
+	RouteNotFound   int64            `json:"routeNotFound"`
+	AuthFailures    int64            `json:"authFailures"`
+	ActionFailures  int64            `json:"actionFailures"`
+	ActiveRequests  int64            `json:"activeRequests"`
+	LastRequestAt   time.Time        `json:"lastRequestAt,omitempty"`
+	StatusCodes     map[string]int64 `json:"statusCodes,omitempty"`
+}
+
+type statsProvider interface {
+	Stats() StatsSnapshot
+}
+
+type runtimeStats struct {
+	mu sync.RWMutex
+
+	requestsTotal   int64
+	requestsHandled int64
+	routeNotFound   int64
+	authFailures    int64
+	actionFailures  int64
+	activeRequests  int64
+	lastRequestAt   time.Time
+	statusCodes     map[string]int64
+}
+
+func newRuntimeStats() *runtimeStats {
+	return &runtimeStats{statusCodes: make(map[string]int64)}
+}
+
+func (s *runtimeStats) Begin(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.requestsTotal++
+	s.activeRequests++
+	s.lastRequestAt = now.UTC()
+}
+
+func (s *runtimeStats) RecordHandled(status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.requestsHandled++
+	s.statusCodes[strconv.Itoa(status)]++
+}
+
+func (s *runtimeStats) RecordRouteNotFound(status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.routeNotFound++
+	s.statusCodes[strconv.Itoa(status)]++
+}
+
+func (s *runtimeStats) RecordAuthFailure(status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.authFailures++
+	s.statusCodes[strconv.Itoa(status)]++
+}
+
+func (s *runtimeStats) RecordActionFailure(status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.actionFailures++
+	s.statusCodes[strconv.Itoa(status)]++
+}
+
+func (s *runtimeStats) End() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activeRequests > 0 {
+		s.activeRequests--
+	}
+}
+
+func (s *runtimeStats) Stats() StatsSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	statusCodes := make(map[string]int64, len(s.statusCodes))
+	for key, value := range s.statusCodes {
+		statusCodes[key] = value
+	}
+
+	return StatsSnapshot{
+		RequestsTotal:   s.requestsTotal,
+		RequestsHandled: s.requestsHandled,
+		RouteNotFound:   s.routeNotFound,
+		AuthFailures:    s.authFailures,
+		ActionFailures:  s.actionFailures,
+		ActiveRequests:  s.activeRequests,
+		LastRequestAt:   s.lastRequestAt,
+		StatusCodes:     statusCodes,
+	}
+}


### PR DESCRIPTION
## Summary
- add in-memory runtime stats for the Fairway daemon with request totals, failures, active requests, last request time, and status code counters
- wire those stats into the HTTP server and expose them through the socket control plane via `stats`
- cover stats collection in the server, daemon, and JSON-RPC socket with focused tests

## Validation
- `gofmt -w addons/fairway/internal/fairway/stats.go addons/fairway/internal/fairway/server.go addons/fairway/internal/fairway/socket.go addons/fairway/internal/fairway/daemon.go addons/fairway/internal/fairway/server_test.go addons/fairway/internal/fairway/socket_test.go addons/fairway/internal/fairway/daemon_test.go`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -cover ./addons/fairway/internal/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go vet ./addons/fairway/...`
- `GOCACHE=/tmp/shipyard-go-build-cache go test -race ./addons/fairway/internal/fairway/ -run 'TestRuntimeStats|TestSocketServerMethods|TestServerHandler|TestDaemonRunLifecycle'`
- `make build-fairway VERSION=0.0.0-dev`