### PR TITLE
style(ui): trocar amarelo por verde escuro nos comandos do CLI

### DIFF
--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -58,7 +58,7 @@ func Muted(text string) string {
 }
 
 func Highlight(text string) string {
-	return Paint(text, StyleBold, StyleYellow)
+	return Paint(text, StyleBold, StyleGreen)
 }
 
 func Emphasis(text string) string {


### PR DESCRIPTION
## Summary

- Alterada a função `Highlight` em `internal/ui/terminal.go` para usar `StyleGreen` (`\033[32m`) em vez de `StyleYellow` (`\033[33m`).
- Todos os nomes de comandos/labels destacados no CLI (root help, service, cron, fairway route, update) passam a ser exibidos em verde escuro.
- Os usos diretos de `StyleYellow` para HTTP 4xx status codes (`fairway_logs.go:328`, `fairway_stats.go:205`, `fairway_route.go:389`) foram mantidos intactos — esses são warnings, não command names.

## Arquivos alterados

| Arquivo | Linhas modificadas |
|---|---|
| `internal/ui/terminal.go` | 1 linha (linha 61: `StyleYellow` → `StyleGreen`) |

Total: 1 arquivo, 1 linha alterada.

## Test plan

Comando executado: `go test ./... -count=1` na raiz do repositório (cobre core + addons/fairway + addons/crew).

Resultado literal:

```
ok  	github.com/shipyard-auto/shipyard/addons/crew/cmd	0.033s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/app	0.005s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew	0.015s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/agent	0.030s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/backend	0.655s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/config	0.014s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/conversation	0.010s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/daemon	0.067s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/logs	0.014s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/mcpserver	0.021s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/pidfile	0.011s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/pool	0.086s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/runner	0.010s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/socket	0.331s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/template	0.008s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/tools	0.471s
ok  	github.com/shipyard-auto/shipyard/addons/crew/internal/crew/trigger	0.013s
ok  	github.com/shipyard-auto/shipyard/addons/fairway/cmd	0.062s
ok  	github.com/shipyard-auto/shipyard/addons/fairway/internal/app	0.005s
ok  	github.com/shipyard-auto/shipyard/addons/fairway/internal/fairway	0.894s
ok  	github.com/shipyard-auto/shipyard/internal/addon	0.012s
ok  	github.com/shipyard-auto/shipyard/internal/cli	0.082s
ok  	github.com/shipyard-auto/shipyard/internal/cli/crew	0.347s
ok  	github.com/shipyard-auto/shipyard/internal/crewctl	0.363s
ok  	github.com/shipyard-auto/shipyard/internal/cron	0.012s
ok  	github.com/shipyard-auto/shipyard/internal/fairwayctl	0.115s
ok  	github.com/shipyard-auto/shipyard/internal/logs	0.007s
ok  	github.com/shipyard-auto/shipyard/internal/metadata	0.011s
ok  	github.com/shipyard-auto/shipyard/internal/service	0.008s
ok  	github.com/shipyard-auto/shipyard/internal/ui/tui/components	0.013s
ok  	github.com/shipyard-auto/shipyard/internal/ui/tui/cronwiz	0.219s
ok  	github.com/shipyard-auto/shipyard/internal/ui/tui/fairwaywiz	0.280s
ok  	github.com/shipyard-auto/shipyard/internal/ui/tui/logwiz	0.066s
ok  	github.com/shipyard-auto/shipyard/internal/ui/tui/servicewiz	0.064s
ok  	github.com/shipyard-auto/shipyard/internal/ui/tui/theme	0.008s
ok  	github.com/shipyard-auto/shipyard/internal/ui/tui/tty	0.005s
ok  	github.com/shipyard-auto/shipyard/internal/uninstall	0.006s
ok  	github.com/shipyard-auto/shipyard/internal/update	0.006s
```

`gofmt -l internal/ui/terminal.go` → saída vazia (arquivo já formatado).

Verificação de amarelo residual: `grep -n 'StyleYellow' internal/ui/terminal.go` retorna apenas a definição da constante na linha 21 — a função `Highlight` (linha 61) não usa mais `StyleYellow`.

## Fora do escopo (intencionalmente)

- `fairway_logs.go:328`, `fairway_stats.go:205`, `fairway_route.go:389` — usos de `StyleYellow` para HTTP 4xx, mantidos amarelos (são warnings de status HTTP, não command names).
- Nenhum helper novo introduzido, nenhuma função renomeada, nenhum pacote reorganizado.
- `manifest` não alterado.
- `.github/` não tocado.
- Addons: nenhum arquivo alterado (não havia uso de `StyleYellow`/`Highlight` nesses pacotes).

## Dúvidas restantes

Nenhuma.

Closes #16