### PR TITLE
style(ui): trocar amarelo por verde escuro nos comandos do CLI

### DIFF
--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -58,7 +58,7 @@ func Muted(text string) string {
 }
 
 func Highlight(text string) string {
-	return Paint(text, StyleBold, StyleYellow)
+	return Paint(text, StyleBold, StyleGreen)
 }
 
 func Emphasis(text string) string {


### PR DESCRIPTION
## Summary

- Substitui a cor amarela (ANSI `33`) por verde escuro (ANSI `32`) na função `Highlight()` em `internal/ui/terminal.go`
- Todos os nomes de comandos e labels de campo exibidos via `ui.Highlight()` passam de amarelo para verde escuro
- Usos diretos de `StyleYellow` para status HTTP 4xx em `fairway_logs.go`, `fairway_stats.go` e `fairway_route.go` permanecem amarelos (são indicadores de aviso, fora do escopo)

## Arquivos alterados

- `internal/ui/terminal.go` — linha 61: `Highlight()` alterada de `StyleBold, StyleYellow` para `StyleBold, StyleGreen` (1 linha modificada)

## Test plan

- `go test ./... -count=1` (raiz, cobre core + addons/fairway + addons/crew) → PASS 34 packages, 0 falhas

Closes #18