### PR TITLE
Revisar textos explicativos de todos os comandos da CLI

### DIFF
--- a/internal/cli/crew/apply.go
+++ b/internal/cli/crew/apply.go
@@ -66,8 +66,12 @@ func newApplyCmd() *cobra.Command {
 func newApplyCmdWith(deps applyDeps) *cobra.Command {
 	var f applyFlags
 	cmd := &cobra.Command{
-		Use:           "apply <name>",
-		Short:         "Reconcile a crew member's triggers with cron and fairway",
+		Use:   "apply <name>",
+		Short: "Sync an AI agent's schedules and webhook routes",
+		Long: `Reads the agent's agent.yaml and registers its scheduled runs as Shipyard
+cron jobs and its webhook endpoints as fairway routes. Run this after
+editing an agent definition or after "shipyard crew hire". Use --dry-run
+to preview changes without applying them.`,
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/internal/cli/crew/crew.go
+++ b/internal/cli/crew/crew.go
@@ -10,7 +10,10 @@ func NewCrewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "crew",
 		Short: "Manage the shipyard-crew LLM agents addon",
-		Long:  "shipyard crew lets you create, configure, and run LLM-backed agents that automate tasks.",
+		Long: `Crew is the AI agent subsystem of Shipyard. Use it to define LLM-backed agents
+that automate tasks on a schedule or in response to HTTP webhooks. Agent
+definitions live under ~/.shipyard/crew/<name>/ and are registered with the
+running daemon via "shipyard crew apply".`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},

--- a/internal/cli/crew/fire.go
+++ b/internal/cli/crew/fire.go
@@ -92,8 +92,12 @@ func newFireCmd() *cobra.Command {
 func newFireCmdWith(deps fireDeps) *cobra.Command {
 	var yes, keepLogs bool
 	cmd := &cobra.Command{
-		Use:           "fire <name>",
-		Short:         "Remove a crew member and clean up its triggers and service",
+		Use:   "fire <name>",
+		Short: "Delete an AI agent and deregister its schedules and routes",
+		Long: `Removes the agent definition directory ~/.shipyard/crew/<name>/, cancels its
+Shipyard cron jobs, deletes its fairway webhook routes, and stops the agent
+service if it runs as one. Logs in ~/.shipyard/logs/crew/<name>/ are also
+removed unless --keep-logs is set.`,
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/internal/cli/crew/hire.go
+++ b/internal/cli/crew/hire.go
@@ -31,8 +31,13 @@ type hireFlags struct {
 func newHireCmd() *cobra.Command {
 	var f hireFlags
 	cmd := &cobra.Command{
-		Use:     "hire <name>",
-		Short:   "Create a new crew member scaffold",
+		Use:   "hire <name>",
+		Short: "Scaffold a new AI agent definition",
+		Long: `Creates a new AI agent under ~/.shipyard/crew/<name>/ with starter
+agent.yaml and prompt.md files. The agent is inert until you register it
+with the running daemon via "shipyard crew apply". Use --backend to choose
+between the Claude CLI and the Anthropic API, and --mode for on-demand or
+persistent-service execution.`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: requireInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/crew/install.go
+++ b/internal/cli/crew/install.go
@@ -29,7 +29,11 @@ func newInstallCmdWith(inst *crewctl.Installer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Install the shipyard-crew addon binary",
+		Short: "Download and install the AI agent runtime",
+		Long: `Downloads the shipyard-crew binary for the current platform and installs it to
+~/.local/bin/. Once installed, the agent runtime is available but no agents
+are active until you run "shipyard crew hire" and "shipyard crew apply". Use
+--force to reinstall an already-present version.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			target := inst
 			if target == nil {

--- a/internal/cli/crew/list.go
+++ b/internal/cli/crew/list.go
@@ -84,8 +84,12 @@ func newListCmdWith(deps listDeps) *cobra.Command {
 	flags := &listFlags{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List registered crew members",
-		Args:  cobra.NoArgs,
+		Short: "List all defined AI agents and their current state",
+		Long: `Scans ~/.shipyard/crew/ and reads each agent.yaml to build a table of AI
+agents. Columns include backend type, execution mode, configured triggers,
+and runtime state (running/stopped for service-mode agents). Use --json for
+machine-readable output or --long to include the description column.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			d := deps
 			d.Verbose = flags.Verbose

--- a/internal/cli/crew/logs.go
+++ b/internal/cli/crew/logs.go
@@ -25,8 +25,12 @@ func newLogsCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "logs <name>",
-		Short: "Show logs for a crew member",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Show execution logs for one or all AI agents",
+		Long: `Reads JSONL execution logs from ~/.shipyard/logs/crew/. Without a name
+argument, shows entries for all agents. Filter by level (--level), trace
+ID (--trace), or time window (--since). Use --follow to stream live output
+as new agent runs complete.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reader, err := newCrewReader()
 			if err != nil {

--- a/internal/cli/crew/run.go
+++ b/internal/cli/crew/run.go
@@ -141,8 +141,13 @@ func NewRunCmd() *cobra.Command {
 func newRunCmdWith(deps runDeps) *cobra.Command {
 	flags := &runFlags{}
 	cmd := &cobra.Command{
-		Use:           "run <name>",
-		Short:         "Run a crew member once",
+		Use:   "run <name>",
+		Short: "Invoke an AI agent once and stream its output",
+		Long: `Executes the named AI agent a single time with optional JSON input. If the
+agent runs as a persistent service, the request is dispatched via the daemon
+socket; otherwise shipyard-crew is spawned as a subprocess. Use --input or
+--input-file to pass structured context, and --timeout to override the
+default five-minute limit.`,
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/internal/cli/crew/tool.go
+++ b/internal/cli/crew/tool.go
@@ -55,8 +55,10 @@ func newToolCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tool",
 		Short: "Manage reusable tools for crew agents",
-		Long: "Tools live in ~/.shipyard/crew/tools/<name>.yaml and can be referenced from\n" +
-			"any agent via `tools: [{ref: <name>}]`. This command group CRUDs that library.",
+		Long: `Tools are reusable functions — either a shell command (--protocol exec) or an
+HTTP request (--protocol http) — stored in ~/.shipyard/crew/tools/<name>.yaml.
+Any AI agent can invoke a tool by listing it in agent.yaml with
+tools: [{ref: <name>}]. Tools are validated by the crew runtime at load time.`,
 		RunE: func(cmd *cobra.Command, args []string) error { return cmd.Help() },
 	}
 	cmd.AddCommand(newToolAddCmd())
@@ -84,8 +86,12 @@ type toolAddFlags struct {
 func newToolAddCmd() *cobra.Command {
 	var f toolAddFlags
 	cmd := &cobra.Command{
-		Use:     "add <name>",
-		Short:   "Create a new tool in the library",
+		Use:   "add <name>",
+		Short: "Define a reusable function for AI agents to invoke",
+		Long: `Adds a tool to ~/.shipyard/crew/tools/<name>.yaml. Tools are reusable
+functions — either a shell command (--protocol exec) or an HTTP request
+(--protocol http) — that any agent can call by referencing them with
+tools: [{ref: <name>}] in its agent.yaml.`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: requireInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -257,8 +263,12 @@ func newToolListCmd() *cobra.Command {
 	var f toolListFlags
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List tools available in the library",
-		Args:  cobra.NoArgs,
+		Short: "List all reusable tool functions in the library",
+		Long: `Reads ~/.shipyard/crew/tools/ and prints each tool's name, protocol (exec or
+http), and description. Files that fail to parse are silently skipped; use
+"shipyard crew tool show <name>" to inspect a specific tool and diagnose
+parse errors.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runToolList(cmd.OutOrStdout(), f)
 		},
@@ -347,8 +357,11 @@ func newToolShowCmd() *cobra.Command {
 	var asJSON bool
 	cmd := &cobra.Command{
 		Use:   "show <name>",
-		Short: "Print a tool's definition",
-		Args:  cobra.ExactArgs(1),
+		Short: "Print the full definition of a tool",
+		Long: `Reads ~/.shipyard/crew/tools/<name>.yaml and prints it as YAML (default) or
+JSON (--json). Useful to verify the exact spec before referencing a tool
+in an agent.yaml.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runToolShow(cmd.OutOrStdout(), args[0], asJSON)
 		},
@@ -395,8 +408,11 @@ type toolRmFlags struct {
 func newToolRmCmd() *cobra.Command {
 	var f toolRmFlags
 	cmd := &cobra.Command{
-		Use:     "rm <name>",
-		Short:   "Remove a tool from the library",
+		Use:   "rm <name>",
+		Short: "Remove a reusable tool from the library",
+		Long: `Deletes ~/.shipyard/crew/tools/<name>.yaml. Before removing, scans all
+agent definitions to check whether any agent references this tool and
+refuses if it finds a match. Use --yes to skip the scan and force removal.`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: requireInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/crew/uninstall.go
+++ b/internal/cli/crew/uninstall.go
@@ -30,7 +30,11 @@ func newUninstallCmdWith(inst *crewctl.Installer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "uninstall",
-		Short: "Remove the shipyard-crew binary (preserves ~/.shipyard/crew/)",
+		Short: "Remove the shipyard-crew AI agent runtime binary",
+		Long: `Removes the shipyard-crew binary from ~/.local/bin/. Agent definitions under
+~/.shipyard/crew/ are preserved so you can reinstall and resume where you left
+off. To deregister individual agents before uninstalling, run "shipyard crew
+fire <name>" for each one. Use --yes to skip the confirmation prompt.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			target := inst
 			if target == nil {

--- a/internal/cli/crew/version.go
+++ b/internal/cli/crew/version.go
@@ -29,6 +29,9 @@ func newVersionCmdWith(inst *crewctl.Installer, coreVersion string) *cobra.Comma
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show shipyard and shipyard-crew versions",
+		Long: `Prints the installed versions of the shipyard core binary and the
+shipyard-crew AI agent runtime addon. Use --json to emit machine-readable
+output suitable for scripts or bug reports.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			core := coreVersion
 			if core == "" {

--- a/internal/cli/fairway.go
+++ b/internal/cli/fairway.go
@@ -21,6 +21,10 @@ func newFairwayCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fairway",
 		Short: "Manage the shipyard-fairway HTTP gateway addon",
+		Long: `Fairway is the HTTP gateway daemon bundled with Shipyard. It listens on a
+configurable address, matches incoming requests to routes, and dispatches
+them to AI agents (crew.run), shell commands (exec), or upstream URLs
+(http.forward). Route definitions and state persist under ~/.shipyard/fairway/.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -73,6 +77,10 @@ func newFairwayInstallCmdWith(installer *fairwayctl.Installer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install the shipyard-fairway HTTP gateway daemon",
+		Long: `Downloads the shipyard-fairway binary for the current platform and registers
+it as a user-level service that starts automatically on login. Route
+definitions and state are stored under ~/.shipyard/fairway/. Use --version
+to pin a specific release or --force to reinstall an existing one.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inst := installer
 			if inst == nil {
@@ -136,6 +144,10 @@ func newFairwayUninstallCmdWith(installer *fairwayctl.Installer) *cobra.Command 
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Short: "Remove the shipyard-fairway daemon and deregister its service",
+		Long: `Stops and removes the shipyard-fairway binary and deregisters it from the
+platform service manager (systemd on Linux, launchd on macOS). Route
+definitions and logs under ~/.shipyard/fairway/ are preserved by default;
+use --purge to delete them as well.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inst := installer
 			if inst == nil {

--- a/internal/cli/fairway_logs.go
+++ b/internal/cli/fairway_logs.go
@@ -12,7 +12,11 @@ import (
 func newFairwayLogsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs",
-		Short: "Show fairway request logs (alias for `shipyard logs show --source fairway`)",
+		Short: "Inspect HTTP request logs from the fairway gateway",
+		Long: `Reads JSONL access and event logs written by the fairway daemon to
+~/.shipyard/logs/fairway/. Supports the same --trace, --id, and --level
+filters as "shipyard logs show". This command group is a focused alias
+that pre-selects the fairway source.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
@@ -29,7 +33,11 @@ func newFairwayLogsShowCmd() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "show",
-		Short: "Show recent fairway log entries",
+		Short: "Print recent HTTP request logs from the fairway gateway",
+		Long: `Reads the most recent JSONL entries from ~/.shipyard/logs/fairway/. Use
+--limit to control how many entries are shown, --trace to follow a single
+request, or --level to filter by severity. Add --json to emit raw JSONL
+instead of pretty output.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if len(opts.filter.sources) == 0 {
 				opts.filter.sources = []string{logs.SourceFairway}
@@ -49,7 +57,10 @@ func newFairwayLogsTailCmd() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "tail",
-		Short: "Tail live fairway log entries",
+		Short: "Stream live HTTP request logs from the fairway gateway",
+		Long: `Follows ~/.shipyard/logs/fairway/ and prints new JSONL entries as they
+arrive. Press Ctrl+C to stop. Supports --trace, --id, and --level filters
+to narrow the stream. Add --json to emit raw JSONL instead of pretty output.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if len(opts.filter.sources) == 0 {
 				opts.filter.sources = []string{logs.SourceFairway}

--- a/internal/cli/fairway_route.go
+++ b/internal/cli/fairway_route.go
@@ -65,7 +65,11 @@ func newFairwayRouteCmd() *cobra.Command {
 func newFairwayRouteCmdWith(deps routeDeps) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "route",
-		Short: "Manage fairway routes through the daemon socket",
+		Short: "Manage HTTP routes in the fairway gateway",
+		Long: `Routes map incoming HTTP paths to an action: run an AI agent (crew.run),
+execute a shell command (exec), or proxy the request to an upstream URL
+(http.forward). Changes take effect immediately via the daemon socket and
+persist across daemon restarts.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -80,8 +84,11 @@ func newFairwayRouteCmdWith(deps routeDeps) *cobra.Command {
 func newFairwayRouteListCmdWith(deps routeDeps) *cobra.Command {
 	var jsonOutput bool
 	cmd := &cobra.Command{
-		Use:           "list",
-		Short:         "List fairway routes",
+		Use:   "list",
+		Short: "List all registered routes in the fairway gateway",
+		Long: `Fetches the current route table from the running fairway daemon and prints
+each route's path, auth type, action, timeout, and sync/async mode. Use
+--json to emit the raw JSON array for scripting.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE:       addon.RequirePreRun(addon.KindFairway),
@@ -111,8 +118,12 @@ func newFairwayRouteListCmdWith(deps routeDeps) *cobra.Command {
 func newFairwayRouteAddCmdWith(deps routeDeps) *cobra.Command {
 	input := &addRouteInput{}
 	cmd := &cobra.Command{
-		Use:           "add",
-		Short:         "Add a new fairway route",
+		Use:   "add",
+		Short: "Register an HTTP route in the fairway gateway",
+		Long: `Maps an incoming HTTP path on the fairway daemon to an action: invoke an AI
+agent (action=crew.run), execute a shell command (action=exec), or proxy
+the request to an upstream URL (action=http.forward). Routes persist across
+daemon restarts.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE:       addon.RequirePreRun(addon.KindFairway),
@@ -163,8 +174,11 @@ func newFairwayRouteAddCmdWith(deps routeDeps) *cobra.Command {
 func newFairwayRouteDeleteCmdWith(deps routeDeps) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:           "delete <path>",
-		Short:         "Delete a fairway route",
+		Use:   "delete <path>",
+		Short: "Remove an HTTP route from the fairway gateway",
+		Long: `Deletes the route for the given path from the running fairway daemon. The
+change is immediate and persists across restarts. In non-interactive mode
+(no TTY), use --yes to confirm deletion without a prompt.`,
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -213,8 +227,12 @@ func newFairwayRouteTestCmdWith(deps routeDeps) *cobra.Command {
 	var headerFlags []string
 
 	cmd := &cobra.Command{
-		Use:           "test <path>",
-		Short:         "Test a fairway route through the daemon",
+		Use:   "test <path>",
+		Short: "Send a test request through a fairway route",
+		Long: `Sends a synthetic HTTP request to the fairway daemon to exercise a route's
+auth and action without an external HTTP client. Prints the response status
+and body. Use --method, --body-file, and --header to simulate different
+request shapes.`,
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/internal/cli/fairway_stats.go
+++ b/internal/cli/fairway_stats.go
@@ -41,8 +41,12 @@ func newFairwayStatsCmdWith(deps fairwayStatsDeps) *cobra.Command {
 	var byStatus bool
 
 	cmd := &cobra.Command{
-		Use:           "stats",
-		Short:         "Show fairway request statistics from the daemon",
+		Use:   "stats",
+		Short: "Show fairway request statistics from the running daemon",
+		Long: `Queries the fairway daemon for live request counters: total request count,
+per-route call counts and error rates, and HTTP status code distribution.
+Use --by-route for a full per-route breakdown, --by-status for the status
+distribution, or --json for the raw snapshot.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE:       addon.RequirePreRun(addon.KindFairway),

--- a/internal/cli/fairway_status.go
+++ b/internal/cli/fairway_status.go
@@ -102,8 +102,12 @@ func newFairwayStatusCmdWith(deps fairwayStatusDeps) *cobra.Command {
 	var jsonOutput bool
 
 	cmd := &cobra.Command{
-		Use:           "status",
-		Short:         "Show fairway installation, service, and daemon status",
+		Use:   "status",
+		Short: "Show fairway installation, service, and daemon status",
+		Long: `Reports whether the fairway daemon is installed, registered as a user service,
+and currently running. When the daemon is live, also shows the bound address,
+uptime, active route count, and a 24-hour traffic summary. Use --json for
+machine-readable output.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -44,7 +44,11 @@ func newLogsCmd() *cobra.Command {
 func newLogsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "List known Shipyard log sources",
+		Short: "List all log sources with file count and size on disk",
+		Long: `Scans ~/.shipyard/logs/ and reports each discovered source (cron, service,
+fairway, crew) with its JSONL file count, total size in bytes, and the
+date of the newest file. Use this to get an overview before running
+show or tail.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reader, err := newLogReader()
 			if err != nil {
@@ -77,7 +81,11 @@ func newLogsShowCmd() *cobra.Command {
 	opts := logShowOptions{}
 	cmd := &cobra.Command{
 		Use:   "show",
-		Short: "Show recent log entries",
+		Short: "Print recent log entries from one or more sources",
+		Long: `Reads JSONL logs under ~/.shipyard/logs/. By default merges all sources
+(cron, service, fairway, crew); filter with --source. Use --trace to follow
+a single request across subsystems (e.g. an HTTP call that triggered an
+agent that ran a shell tool), or --id to scope to a specific entity.`,
 		Example: strings.Join([]string{
 			"shipyard logs show --source cron",
 			"shipyard logs show --source cron --id AB12CD --limit 20",
@@ -98,7 +106,10 @@ func newLogsTailCmd() *cobra.Command {
 	opts := logShowOptions{}
 	cmd := &cobra.Command{
 		Use:   "tail",
-		Short: "Tail live Shipyard logs",
+		Short: "Stream live log entries as they are written",
+		Long: `Follows ~/.shipyard/logs/ and prints new entries as each subsystem writes
+them. Press Ctrl+C to stop. Supports the same --source, --trace, --id,
+and --level filters as "shipyard logs show".`,
 		Example: strings.Join([]string{
 			"shipyard logs tail --source cron",
 			"shipyard logs tail --source cron --id AB12CD",
@@ -282,7 +293,11 @@ func newLogReader() (*logs.Reader, error) {
 func newLogsPruneCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "prune",
-		Short: "Delete logs older than the retention policy",
+		Short: "Delete log files older than the configured retention period",
+		Long: `Removes JSONL log files under ~/.shipyard/logs/ that are older than the
+current retention setting (default 30 days). Reports the number of files
+deleted and bytes freed. Adjust the retention period with
+"shipyard logs config set retention-days <n>".`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			service, err := logs.NewService()
 			if err != nil {
@@ -304,6 +319,10 @@ func newLogsConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Show or update logs configuration",
+		Long: `Without arguments and with a TTY, opens an interactive panel to view and
+update log settings. For scripting, use the "set" subcommand, e.g.
+"shipyard logs config set retention-days 30". The only configurable setting
+today is retention-days, which controls how long log files are kept.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 && tuitype.IsInteractive(tuitype.StdinFD()) {
 				service, err := logs.NewService()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -14,7 +14,7 @@ import (
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           app.Name,
-		Short:         "Shipyard command line tool",
+		Short:         "Local automation toolkit for cron, services, HTTP and AI agents",
 		Long:          app.Description,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/manifest
+++ b/manifest
@@ -1,3 +1,3 @@
-shipyard=1.3.1
+shipyard=1.3.2
 fairway=1.3.0
 crew=0.3.9


### PR DESCRIPTION
## Summary

- Rewrote `Short` fields across `crew`, `fairway`, and `logs` subsystems to follow the imperative-verb + direct-object pattern (≤ 70 chars) and eliminate jargon ("crew member", "reconcile", "triggers", "addon").
- Added missing `Long` fields (2–4 sentences each) to every subcommand in `crew`, `fairway`, and `logs` — covering what the command does, where state lives, and when to use it.
- Used "AI agent" consistently throughout the `crew` subsystem; no command uses "crew member" without context anymore.
- Updated root `Short` to `"Local automation toolkit for cron, services, HTTP and AI agents"`.

## Arquivos alterados

- `internal/cli/root.go` — updated root Short
- `internal/cli/crew/crew.go` — improved Long (2-4 sentences)
- `internal/cli/crew/install.go` — new Short + Long
- `internal/cli/crew/uninstall.go` — new Short + Long
- `internal/cli/crew/version.go` — added Long
- `internal/cli/crew/hire.go` — new Short ("Scaffold a new AI agent definition") + Long
- `internal/cli/crew/fire.go` — new Short (uses "AI agent", drops "triggers" jargon) + Long
- `internal/cli/crew/apply.go` — new Short ("Sync an AI agent's schedules and webhook routes") + Long
- `internal/cli/crew/list.go` — new Short + Long
- `internal/cli/crew/run.go` — new Short + Long
- `internal/cli/crew/logs.go` — new Short + Long
- `internal/cli/crew/tool.go` — improved Long on parent; new Short + Long on add/list/show/rm
- `internal/cli/fairway.go` — added Long on root, install, uninstall
- `internal/cli/fairway_status.go` — added Long
- `internal/cli/fairway_stats.go` — added Long
- `internal/cli/fairway_route.go` — new Short on route/list/add/delete/test + Long on all
- `internal/cli/fairway_logs.go` — new Short on parent/show/tail + Long on all
- `internal/cli/logs.go` — new Short on list/show/tail/prune; added Long on all five subcommands

## Test plan

- `GOTOOLCHAIN=go1.26.2 go test ./... -count=1` → **ok 38 packages, 0 failures**
- `shipyard crew --help` → output below:

```
SHIPYARD CREW
Shipyard command reference

Crew is the AI agent subsystem of Shipyard. Use it to define LLM-backed agents
that automate tasks on a schedule or in response to HTTP webhooks. Agent
definitions live under ~/.shipyard/crew/<name>/ and are registered with the
running daemon via "shipyard crew apply".

Usage
  shipyard crew [flags]

Available Commands
  apply        Sync an AI agent's schedules and webhook routes
  fire         Delete an AI agent and deregister its schedules and routes
  hire         Scaffold a new AI agent definition
  install      Download and install the AI agent runtime
  list         List all defined AI agents and their current state
  logs         Show execution logs for one or all AI agents
  run          Invoke an AI agent once and stream its output
  tool         Manage reusable tools for crew agents
  uninstall    Remove the shipyard-crew AI agent runtime binary
  version      Show shipyard and shipyard-crew versions
```

- `shipyard fairway --help` → output below:

```
SHIPYARD FAIRWAY
Shipyard command reference

Fairway is the HTTP gateway daemon bundled with Shipyard. It listens on a
configurable address, matches incoming requests to routes, and dispatches
them to AI agents (crew.run), shell commands (exec), or upstream URLs
(http.forward). Route definitions and state persist under ~/.shipyard/fairway/.

Usage
  shipyard fairway [flags]

Available Commands
  config       Interactive fairway route configuration wizard
  install      Install the shipyard-fairway HTTP gateway daemon
  logs         Inspect HTTP request logs from the fairway gateway
  route        Manage HTTP routes in the fairway gateway
  stats        Show fairway request statistics from the running daemon
  status       Show fairway installation, service, and daemon status
  uninstall    Remove the shipyard-fairway daemon and deregister its service
```

- `shipyard logs --help` → output below:

```
SHIPYARD LOGS
Shipyard command reference

Inspect local Shipyard logs stored in ~/.shipyard/logs as JSONL files.

Sources are discovered automatically; use --source to narrow the query.
All entries follow the schema-v2 flat layout (snake_case keys).

Usage
  shipyard logs [flags]

Available Commands
  config       Show or update logs configuration
  list         List all log sources with file count and size on disk
  prune        Delete log files older than the configured retention period
  show         Print recent log entries from one or more sources
  tail         Stream live log entries as they are written
```

**Fora do escopo (intencional):** nomes de comandos (hire, fire, apply) não foram alterados; mensagens de erro em runtime não foram tocadas; `manifest` e `.github/workflows/` não foram modificados; `cron` e `service` não foram reescritos (já consistentes).

Closes #28