### PR TITLE
shipyard uninstall em cascata sobre addons instalados

### DIFF
--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bufio"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,19 +12,39 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/shipyard-auto/shipyard/internal/addon"
 	"github.com/shipyard-auto/shipyard/internal/uninstall"
 )
 
+// uninstallAddonFunc desinstala um addon específico. Variável package-level
+// para permitir override em testes. NÃO exportar — mantém o blast radius
+// pequeno.
+type uninstallAddonFunc func(ctx context.Context) error
+
+// loadInstalledAddons devolve a lista (ordenada e estável) de addons marcados
+// como instalados no registry ~/.shipyard/addons.json. Variável para testes.
+var loadInstalledAddons = defaultLoadInstalledAddons
+
+// uninstallCrewAddon executa o uninstall do crew. Variável para testes.
+var uninstallCrewAddon uninstallAddonFunc = defaultUninstallCrewAddon
+
+// uninstallFairwayAddon executa o uninstall do fairway. Variável para testes.
+var uninstallFairwayAddon uninstallAddonFunc = defaultUninstallFairwayAddon
+
 func newUninstallCmd() *cobra.Command {
 	var assumeYes bool
+	var keepAddons bool
 
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Short: "Remove Shipyard completely from this machine",
-		Long:  "Delete the Shipyard binary and the ~/.shipyard directory created during installation.",
+		Long: `Delete the Shipyard binary and the ~/.shipyard directory created during
+installation. Detected addons (crew, fairway) are uninstalled in cascade by
+default; pass --keep-addons to leave them in place.`,
 		Example: strings.Join([]string{
 			"shipyard uninstall",
 			"shipyard uninstall --yes",
+			"shipyard uninstall --yes --keep-addons",
 		}, "\n"),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			executablePath, err := os.Executable()
@@ -46,6 +68,10 @@ func newUninstallCmd() *cobra.Command {
 				}
 			}
 
+			if !keepAddons {
+				cascadeUninstallAddons(cmd)
+			}
+
 			service := uninstall.NewService()
 			result, err := service.Run(executablePath)
 			if err != nil {
@@ -63,6 +89,7 @@ func newUninstallCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "Run without interactive confirmation")
+	cmd.Flags().BoolVar(&keepAddons, "keep-addons", false, "Skip uninstalling detected addons (crew, fairway)")
 
 	return cmd
 }
@@ -88,4 +115,89 @@ func removedLabel(removed bool, path string) string {
 	}
 
 	return path + " (not found)"
+}
+
+// cascadeUninstallAddons uninstalls every addon currently marked as installed
+// in the registry. Failures are reported as warnings on stdout — they never
+// block the core uninstall, because by the time the user typed `shipyard
+// uninstall` the intent is already to wipe the machine.
+func cascadeUninstallAddons(cmd *cobra.Command) {
+	out := cmd.OutOrStdout()
+	kinds := loadInstalledAddons()
+	if len(kinds) == 0 {
+		return
+	}
+
+	var errs []error
+	for _, kind := range kinds {
+		var fn uninstallAddonFunc
+		switch kind {
+		case addon.KindCrew:
+			fn = uninstallCrewAddon
+		case addon.KindFairway:
+			fn = uninstallFairwayAddon
+		default:
+			// Unknown kinds: log and skip. Registry may be from a future
+			// shipyard version; refusing here would block a legitimate
+			// uninstall.
+			PrintResult(out, "Skipped unknown addon: %s\n", kind)
+			continue
+		}
+		if err := fn(cmd.Context()); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", kind, err))
+			PrintResult(out, "Warning: failed to uninstall %s addon: %v\n", kind, err)
+			continue
+		}
+		_ = addon.NewRegistry("").Forget(kind)
+		PrintResult(out, "Removed addon: %s\n", kind)
+	}
+
+	if joined := errors.Join(errs...); joined != nil {
+		// Print summary; do NOT return — the core uninstall must proceed.
+		PrintResult(out, "Some addons could not be removed cleanly. Re-run their individual uninstall commands manually if needed.\n")
+	}
+}
+
+// defaultLoadInstalledAddons reads the addon registry and returns the kinds
+// marked as installed, sorted alphabetically for deterministic output.
+func defaultLoadInstalledAddons() []addon.Kind {
+	reg := addon.NewRegistry("")
+	file, err := reg.Load()
+	if err != nil || file == nil {
+		return nil
+	}
+	out := make([]addon.Kind, 0, len(file.Addons))
+	for kind, info := range file.Addons {
+		if info != nil && info.Installed {
+			out = append(out, kind)
+		}
+	}
+	// Sort by string value for determinism (test stability).
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// defaultUninstallCrewAddon builds the production crew installer and runs
+// Uninstall on it. The Version field is irrelevant for uninstall, so we pass
+// an empty string.
+func defaultUninstallCrewAddon(ctx context.Context) error {
+	inst, err := buildCrewInstallerForUpdate("")
+	if err != nil {
+		return err
+	}
+	return inst.Uninstall(ctx)
+}
+
+// defaultUninstallFairwayAddon builds the production fairway installer and
+// runs Uninstall on it.
+func defaultUninstallFairwayAddon(ctx context.Context) error {
+	inst, err := buildInstaller("")
+	if err != nil {
+		return err
+	}
+	return inst.Uninstall(ctx)
 }

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/shipyard-auto/shipyard/internal/addon"
+)
+
+// isolateHome aponta $HOME para um diretório temporário antes do teste,
+// garantindo que addon.NewRegistry("").Forget(...) escreva no tmpdir e não
+// no ~/.shipyard real do desenvolvedor. Sempre chame no início do teste.
+func isolateHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+}
+
+// stubAddonHooks substitui as três variáveis package-level por doubles e
+// restaura no t.Cleanup. Devolve ponteiros para contadores das duas
+// chamadas de uninstall, para asserts no teste chamador.
+type addonHookStubs struct {
+	crewCalls    *int
+	fairwayCalls *int
+}
+
+func stubAddonHooks(t *testing.T, kinds []addon.Kind, crewErr, fairwayErr error) addonHookStubs {
+	t.Helper()
+	origLoad := loadInstalledAddons
+	origCrew := uninstallCrewAddon
+	origFairway := uninstallFairwayAddon
+
+	var crewCalls, fairwayCalls int
+	loadInstalledAddons = func() []addon.Kind { return kinds }
+	uninstallCrewAddon = func(ctx context.Context) error {
+		crewCalls++
+		return crewErr
+	}
+	uninstallFairwayAddon = func(ctx context.Context) error {
+		fairwayCalls++
+		return fairwayErr
+	}
+
+	t.Cleanup(func() {
+		loadInstalledAddons = origLoad
+		uninstallCrewAddon = origCrew
+		uninstallFairwayAddon = origFairway
+	})
+	return addonHookStubs{crewCalls: &crewCalls, fairwayCalls: &fairwayCalls}
+}
+
+func newCmdForTest() (*cobra.Command, *bytes.Buffer) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetContext(context.Background())
+	return cmd, &buf
+}
+
+func TestCascadeUninstallAddons_runsBoth(t *testing.T) {
+	isolateHome(t)
+	stubs := stubAddonHooks(t,
+		[]addon.Kind{addon.KindCrew, addon.KindFairway},
+		nil, nil,
+	)
+
+	cmd, buf := newCmdForTest()
+	cascadeUninstallAddons(cmd)
+
+	if *stubs.crewCalls != 1 {
+		t.Fatalf("crew uninstall calls: got %d want 1", *stubs.crewCalls)
+	}
+	if *stubs.fairwayCalls != 1 {
+		t.Fatalf("fairway uninstall calls: got %d want 1", *stubs.fairwayCalls)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Removed addon: crew") {
+		t.Errorf("missing crew removal line:\n%s", out)
+	}
+	if !strings.Contains(out, "Removed addon: fairway") {
+		t.Errorf("missing fairway removal line:\n%s", out)
+	}
+}
+
+func TestCascadeUninstallAddons_continuesOnFailure(t *testing.T) {
+	isolateHome(t)
+	stubs := stubAddonHooks(t,
+		[]addon.Kind{addon.KindCrew, addon.KindFairway},
+		errors.New("simulated crew failure"), nil,
+	)
+
+	cmd, buf := newCmdForTest()
+	cascadeUninstallAddons(cmd)
+
+	if *stubs.fairwayCalls != 1 {
+		t.Fatalf("fairway uninstall must run even after crew fails: got %d", *stubs.fairwayCalls)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Warning: failed to uninstall crew") {
+		t.Errorf("missing crew warning:\n%s", out)
+	}
+	if !strings.Contains(out, "Removed addon: fairway") {
+		t.Errorf("fairway should still be reported as removed:\n%s", out)
+	}
+}
+
+func TestCascadeUninstallAddons_emptyRegistryNoop(t *testing.T) {
+	isolateHome(t)
+	stubAddonHooks(t, nil, nil, nil)
+
+	cmd, buf := newCmdForTest()
+	cascadeUninstallAddons(cmd)
+
+	if buf.Len() != 0 {
+		t.Errorf("empty registry must produce no output, got: %q", buf.String())
+	}
+}
+
+func TestCascadeUninstallAddons_skipsUnknownKind(t *testing.T) {
+	isolateHome(t)
+	stubs := stubAddonHooks(t,
+		[]addon.Kind{addon.Kind("ghost"), addon.KindCrew},
+		nil, nil,
+	)
+
+	cmd, buf := newCmdForTest()
+	cascadeUninstallAddons(cmd)
+
+	if *stubs.crewCalls != 1 {
+		t.Fatalf("crew must still run after unknown kind: got %d", *stubs.crewCalls)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Skipped unknown addon: ghost") {
+		t.Errorf("missing skip line:\n%s", out)
+	}
+}

--- a/manifest
+++ b/manifest
@@ -1,3 +1,3 @@
-shipyard=1.3.2
+shipyard=1.3.3
 fairway=1.3.0
 crew=0.3.9


### PR DESCRIPTION
## Summary
- `shipyard uninstall` now uninstalls detected addons (crew, fairway) in cascade **before** removing `~/.shipyard/`, via injectable package-level vars `uninstallCrewAddon` and `uninstallFairwayAddon`.
- Added `--keep-addons` flag to opt out of cascade uninstall.
- Failures per addon are reported as warnings on stdout and never block the core uninstall.

## Arquivos alterados
- `internal/cli/uninstall.go` — added `cascadeUninstallAddons`, `defaultLoadInstalledAddons`, `defaultUninstallCrewAddon`, `defaultUninstallFairwayAddon`; added package-level injectable vars; added `--keep-addons` flag to `newUninstallCmd`; updated Long/Example docs.
- `internal/cli/uninstall_test.go` — new file; 4 table-driven tests covering: both addons removed, continues on failure, noop on empty registry, skips unknown kind.

## Test plan
- `GOTOOLCHAIN=go1.26.2 go build ./cmd/shipyard` → BUILD_OK
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli/... -count=1 -run Cascade` → PASS 4/4 (TestCascadeUninstallAddons_runsBoth, _continuesOnFailure, _emptyRegistryNoop, _skipsUnknownKind)
- `GOTOOLCHAIN=go1.26.2 go test ./... -count=1` → ok 38 packages, 0 failures
- `./shipyard uninstall --help | grep keep-addons` → `      --keep-addons   Skip uninstalling detected addons (crew, fairway)`

Fora de escopo de propósito: `internal/uninstall/service.go`, `internal/crewctl/`, `internal/fairwayctl/`, `internal/addon/`, manifest, workflows.

Não validei: smoke manual com addons reais instalados (ambiente descartável não disponível neste executor). Os testes unitários cobrem todos os 4 cenários descritos na issue com doubles de uninstall.

Closes #30