### PR TITLE
Picker de crew agents no wizard shipyard fairway config

### DIFF
--- a/internal/ui/tui/fairwaywiz/fairwaywiz_test.go
+++ b/internal/ui/tui/fairwaywiz/fairwaywiz_test.go
@@ -724,7 +724,17 @@ func TestFormScreen_crewRun_emptyFallsBackToInput(t *testing.T) {
 func TestFormScreen_crewRun_crewMissingFallsBackToInput(t *testing.T) {
 	stubCrewPicker(t, false, nil, nil)
 
-	scr := newCrewRunFormScreen(t)
+	// Simula edição legada: a rota original tinha crew.run, mas o crew foi
+	// desinstalado depois. allowCrewRun=true no construtor mantém a opção
+	// habilitada e a seleção pré-existente sobrevive — caímos no fallback do
+	// step Target porque s.crewAddon.Installed=false.
+	original := &fairwayctl.Route{
+		Path:   "/hooks/legacy",
+		Auth:   fairwayctl.Auth{Type: fairwayctl.AuthLocalOnly},
+		Action: fairwayctl.Action{Type: fairwayctl.ActionCrewRun},
+	}
+	scr := newFormScreen(theme.New(), nil, original).(*formScreen)
+	scr.focus = fieldActionTarget
 	_ = scr.renderCurrentStep()
 
 	if scr.crewPickerActive() {
@@ -817,5 +827,53 @@ func TestBuildActionOptions_legacyEdit_keepsCrewRunEnabled(t *testing.T) {
 	}
 	if got.Disabled {
 		t.Errorf("crew.run must remain enabled when editing a legacy route (avoids silent reselection)")
+	}
+}
+
+// TestFormScreen_actionMenu_*: validam o caminho de produção — newFormScreen
+// precisa chamar buildActionOptions ao construir o actionMenu. Estes testes
+// inspecionam a View() renderizada porque components.Menu não expõe a slice
+// interna. Sem eles, a feature pode ficar "desconectada": buildActionOptions
+// existe e é testada como função pura, mas o construtor passa actionOptions
+// direto. Foi exatamente o bug capturado na revisão do PR #33.
+
+func TestFormScreen_actionMenu_disablesCrewRunWhenCrewAbsent(t *testing.T) {
+	stubCrewPicker(t, false, nil, nil)
+
+	scr := newFormScreen(theme.New(), nil, nil).(*formScreen)
+	view := scr.actionType.View()
+
+	if !strings.Contains(view, "install crew") {
+		t.Errorf("actionMenu must render the 'install crew' badge when crew addon is absent — buildActionOptions is likely not wired into newFormScreen.\nrendered view:\n%s", view)
+	}
+}
+
+func TestFormScreen_actionMenu_noBadgeWhenCrewInstalled(t *testing.T) {
+	stubCrewPicker(t, true, nil, nil)
+
+	scr := newFormScreen(theme.New(), nil, nil).(*formScreen)
+	view := scr.actionType.View()
+
+	if strings.Contains(view, "install crew") {
+		t.Errorf("actionMenu must NOT render 'install crew' badge when crew is installed.\nrendered view:\n%s", view)
+	}
+}
+
+func TestFormScreen_actionMenu_legacyEditKeepsCrewRunEnabled(t *testing.T) {
+	stubCrewPicker(t, false, nil, nil)
+
+	original := &fairwayctl.Route{
+		Path: "/hooks/legacy",
+		Auth: fairwayctl.Auth{Type: fairwayctl.AuthLocalOnly},
+		Action: fairwayctl.Action{
+			Type:   fairwayctl.ActionCrewRun,
+			Target: "ghost-agent",
+		},
+	}
+	scr := newFormScreen(theme.New(), nil, original).(*formScreen)
+	view := scr.actionType.View()
+
+	if strings.Contains(view, "install crew") {
+		t.Errorf("editing a legacy crew.run route must keep the option enabled (no badge), even when crew is absent.\nrendered view:\n%s", view)
 	}
 }

--- a/internal/ui/tui/fairwaywiz/fairwaywiz_test.go
+++ b/internal/ui/tui/fairwaywiz/fairwaywiz_test.go
@@ -11,7 +11,10 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
 
+	"github.com/shipyard-auto/shipyard/internal/addon"
+	"github.com/shipyard-auto/shipyard/internal/crewctl"
 	"github.com/shipyard-auto/shipyard/internal/fairwayctl"
+	"github.com/shipyard-auto/shipyard/internal/ui/tui/components"
 	"github.com/shipyard-auto/shipyard/internal/ui/tui/theme"
 )
 
@@ -658,5 +661,161 @@ func TestForm_metadataNavigationAndSections(t *testing.T) {
 	}
 	if !strings.Contains(screen.submitPanel(), "save route") {
 		t.Fatalf("unexpected submit panel: %q", screen.submitPanel())
+	}
+}
+
+// ====== X-03 picker tests ======
+
+func stubCrewPicker(t *testing.T, installed bool, agents []crewctl.AgentInfo, listErr error) {
+	t.Helper()
+	origList := listCrewAgents
+	origDetect := detectCrewAddon
+	listCrewAgents = func() ([]crewctl.AgentInfo, error) { return agents, listErr }
+	detectCrewAddon = func() addon.Info { return addon.Info{Kind: addon.KindCrew, Installed: installed} }
+	t.Cleanup(func() {
+		listCrewAgents = origList
+		detectCrewAddon = origDetect
+	})
+}
+
+func newCrewRunFormScreen(t *testing.T) *formScreen {
+	t.Helper()
+	scr := newFormScreen(theme.New(), nil, nil).(*formScreen)
+	scr.actionType.SetSelectedByKey(string(fairwayctl.ActionCrewRun))
+	scr.focus = fieldActionTarget
+	return scr
+}
+
+func TestFormScreen_crewRun_listsAgents(t *testing.T) {
+	stubCrewPicker(t, true, []crewctl.AgentInfo{
+		{Name: "alpha", Description: "first agent"},
+		{Name: "beta", Description: "second agent"},
+	}, nil)
+
+	scr := newCrewRunFormScreen(t)
+	view := scr.renderCurrentStep()
+
+	if !strings.Contains(view, "alpha") || !strings.Contains(view, "beta") {
+		t.Fatalf("menu must list both agents:\n%s", view)
+	}
+	if !scr.crewPickerActive() {
+		t.Fatalf("crewPickerActive must be true with installed crew + non-empty list")
+	}
+	if scr.crewMenu.Selected().Key != "alpha" {
+		t.Errorf("default selection should be the first agent, got %q", scr.crewMenu.Selected().Key)
+	}
+}
+
+func TestFormScreen_crewRun_emptyFallsBackToInput(t *testing.T) {
+	stubCrewPicker(t, true, nil, nil)
+
+	scr := newCrewRunFormScreen(t)
+	_ = scr.renderCurrentStep() // triggers loadCrewAgentsOnce
+
+	if scr.crewPickerActive() {
+		t.Fatalf("picker must be inactive when list is empty")
+	}
+	view := scr.renderCurrentStep()
+	if !strings.Contains(view, "shipyard crew hire") {
+		t.Errorf("fallback hint should mention `shipyard crew hire`:\n%s", view)
+	}
+}
+
+func TestFormScreen_crewRun_crewMissingFallsBackToInput(t *testing.T) {
+	stubCrewPicker(t, false, nil, nil)
+
+	scr := newCrewRunFormScreen(t)
+	_ = scr.renderCurrentStep()
+
+	if scr.crewPickerActive() {
+		t.Fatalf("picker must be inactive when crew addon is not installed")
+	}
+	view := scr.renderCurrentStep()
+	if !strings.Contains(view, "shipyard crew install") {
+		t.Errorf("fallback hint should mention `shipyard crew install`:\n%s", view)
+	}
+}
+
+func TestFormScreen_crewRun_preselectsExistingTarget(t *testing.T) {
+	stubCrewPicker(t, true, []crewctl.AgentInfo{
+		{Name: "alpha"},
+		{Name: "beta"},
+		{Name: "gamma"},
+	}, nil)
+
+	original := &fairwayctl.Route{
+		Path: "/hooks/x",
+		Auth: fairwayctl.Auth{Type: fairwayctl.AuthLocalOnly},
+		Action: fairwayctl.Action{
+			Type:   fairwayctl.ActionCrewRun,
+			Target: "beta",
+		},
+	}
+	scr := newFormScreen(theme.New(), nil, original).(*formScreen)
+	scr.focus = fieldActionTarget
+
+	_ = scr.renderCurrentStep() // triggers load
+	if got := scr.crewMenu.Selected().Key; got != "beta" {
+		t.Errorf("preselection failed: got %q want %q", got, "beta")
+	}
+}
+
+// findActionOption busca um MenuItem por Key dentro de uma slice retornada
+// por buildActionOptions. Testamos a função pura em vez de inspecionar o
+// estado interno do Menu, porque Menu.SetSelectedByKey pula items Disabled
+// (chama ensureSelectable internamente) — o que mascararia o comportamento
+// que estamos verificando.
+func findActionOption(items []components.MenuItem, key string) (components.MenuItem, bool) {
+	for _, item := range items {
+		if item.Key == key {
+			return item, true
+		}
+	}
+	return components.MenuItem{}, false
+}
+
+func TestBuildActionOptions_crewMissing_disablesCrewRun(t *testing.T) {
+	items := buildActionOptions(false, false)
+
+	got, ok := findActionOption(items, string(fairwayctl.ActionCrewRun))
+	if !ok {
+		t.Fatalf("crew.run option must remain visible in the menu (just disabled)")
+	}
+	if !got.Disabled {
+		t.Errorf("crew.run must be Disabled when crew addon is absent")
+	}
+	if got.Badge != "install crew" {
+		t.Errorf("crew.run badge: got %q want %q", got.Badge, "install crew")
+	}
+}
+
+func TestBuildActionOptions_crewInstalled_enablesCrewRun(t *testing.T) {
+	items := buildActionOptions(true, false)
+
+	got, ok := findActionOption(items, string(fairwayctl.ActionCrewRun))
+	if !ok {
+		t.Fatalf("crew.run option missing from menu")
+	}
+	if got.Disabled {
+		t.Errorf("crew.run must be enabled when crew addon is installed")
+	}
+	if got.Badge != "" {
+		t.Errorf("crew.run badge must be empty when enabled, got %q", got.Badge)
+	}
+}
+
+func TestBuildActionOptions_legacyEdit_keepsCrewRunEnabled(t *testing.T) {
+	// crewInstalled=false (crew foi desinstalado) mas allowCrewRun=true
+	// (rota original já tinha crew.run salvo). Não pode desabilitar — caso
+	// contrário SetSelectedByKey no construtor cairia em ensureSelectable e
+	// trocaria silenciosamente a seleção do usuário, perdendo dado.
+	items := buildActionOptions(false, true)
+
+	got, ok := findActionOption(items, string(fairwayctl.ActionCrewRun))
+	if !ok {
+		t.Fatalf("crew.run option missing from menu")
+	}
+	if got.Disabled {
+		t.Errorf("crew.run must remain enabled when editing a legacy route (avoids silent reselection)")
 	}
 }

--- a/internal/ui/tui/fairwaywiz/form.go
+++ b/internal/ui/tui/fairwaywiz/form.go
@@ -65,10 +65,11 @@ func newFormScreen(th theme.Theme, client FairwayClient, route *fairwayctl.Route
 	timeout.SetValue(state.Timeout)
 
 	crewAddon := detectCrewAddon()
+	allowCrewRun := route != nil && route.Action.Type == fairwayctl.ActionCrewRun
 
 	authMenu := components.NewMenu(th, authOptions)
 	authMenu.SetSelectedByKey(state.AuthType)
-	actionMenu := components.NewMenu(th, actionOptions)
+	actionMenu := components.NewMenu(th, buildActionOptions(crewAddon.Installed, allowCrewRun))
 	actionMenu.SetSelectedByKey(state.ActionType)
 
 	authSecret.SetValue(state.AuthSecret)

--- a/internal/ui/tui/fairwaywiz/form.go
+++ b/internal/ui/tui/fairwaywiz/form.go
@@ -6,6 +6,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/shipyard-auto/shipyard/internal/addon"
+	"github.com/shipyard-auto/shipyard/internal/crewctl"
 	"github.com/shipyard-auto/shipyard/internal/fairwayctl"
 	"github.com/shipyard-auto/shipyard/internal/ui/tui/components"
 	"github.com/shipyard-auto/shipyard/internal/ui/tui/theme"
@@ -36,6 +38,10 @@ type formScreen struct {
 	authLookup components.Input
 	actionType components.Menu
 	actionTgt  components.Input
+	crewMenu   components.Menu     // populado lazy quando action = crew.run
+	crewAgents []crewctl.AgentInfo // empty se crew ausente OU sem agentes
+	crewAddon  addon.Info          // resultado da última Detect
+	crewLoaded bool                // garante que carregamos só uma vez
 	actionMeta components.Input
 	timeout    components.Input
 	focus      formField
@@ -57,6 +63,8 @@ func newFormScreen(th theme.Theme, client FairwayClient, route *fairwayctl.Route
 	timeout := components.NewInput(th, "Timeout", "30s", nil)
 	timeout.SetHint("Optional. Leave empty to inherit the daemon default.")
 	timeout.SetValue(state.Timeout)
+
+	crewAddon := detectCrewAddon()
 
 	authMenu := components.NewMenu(th, authOptions)
 	authMenu.SetSelectedByKey(state.AuthType)
@@ -86,6 +94,7 @@ func newFormScreen(th theme.Theme, client FairwayClient, route *fairwayctl.Route
 		authLookup: authLookup,
 		actionType: actionMenu,
 		actionTgt:  actionTarget,
+		crewAddon:  crewAddon,
 		actionMeta: actionMeta,
 		timeout:    timeout,
 	}
@@ -136,6 +145,10 @@ func (s *formScreen) Update(msg tea.Msg) (Screen, tea.Cmd) {
 		s.authType = menu
 		action := s.actionType.SetWidth(msg.Width)
 		s.actionType = action
+		if s.crewLoaded && len(s.crewAgents) > 0 {
+			crewSized := s.crewMenu.SetWidth(msg.Width)
+			s.crewMenu = crewSized
+		}
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "esc":
@@ -197,6 +210,20 @@ func (s *formScreen) Update(msg tea.Msg) (Screen, tea.Cmd) {
 		}
 		return s, nil
 	case fieldActionTarget:
+		if s.crewPickerActive() {
+			menu, cmd := s.crewMenu.Update(msg)
+			s.crewMenu = menu
+			if cmd != nil {
+				// Enter no menu sinaliza seleção: copia a key para actionTgt
+				// para que routeFromFormState (que lê s.actionTgt) capture o
+				// valor correto, e avança o passo.
+				s.actionTgt.SetValue(s.crewMenu.Selected().Key)
+				s.err = ""
+				s.focus = s.nextField()
+				s.syncFocus()
+			}
+			return s, nil
+		}
 		cmd, _ := s.actionTgt.Update(msg)
 		return s, cmd
 	case fieldActionMeta:
@@ -251,6 +278,69 @@ func (s *formScreen) View() string {
 	return strings.Join(parts, "\n\n")
 }
 
+// loadCrewAgentsOnce popula s.crewMenu e s.crewAgents na primeira chamada.
+// Idempotente: chamadas subsequentes são no-op. Não falha o wizard quando o
+// crew está ausente ou listing falha — o caller cai no fallback do Input.
+//
+// Pré-condição: s.crewAddon já foi populado em newFormScreen (ver Passo 3-bis).
+func (s *formScreen) loadCrewAgentsOnce() {
+	if s.crewLoaded {
+		return
+	}
+	s.crewLoaded = true
+
+	if !s.crewAddon.Installed {
+		return
+	}
+
+	agents, err := listCrewAgents()
+	if err != nil || len(agents) == 0 {
+		return
+	}
+	s.crewAgents = agents
+
+	items := make([]components.MenuItem, 0, len(agents))
+	for _, a := range agents {
+		desc := a.Description
+		if desc == "" {
+			desc = "backend=" + a.Backend
+		}
+		items = append(items, components.MenuItem{
+			Title:       a.Name,
+			Description: desc,
+			Key:         a.Name,
+		})
+	}
+	s.crewMenu = components.NewMenu(s.theme, items)
+
+	// Preserva seleção quando editando rota existente que aponta para um
+	// agente conhecido. SetSelectedByKey é no-op quando a key não existe.
+	if s.original != nil &&
+		s.original.Action.Type == fairwayctl.ActionCrewRun &&
+		s.original.Action.Target != "" {
+		s.crewMenu.SetSelectedByKey(s.original.Action.Target)
+	}
+}
+
+// crewPickerActive retorna true quando o step ActionTarget deve renderizar o
+// menu de crew agents em vez do Input. Exige (a) action == crew.run, (b) crew
+// instalado, (c) lista não-vazia.
+func (s *formScreen) crewPickerActive() bool {
+	if fairwayctl.ActionType(s.actionType.Selected().Key) != fairwayctl.ActionCrewRun {
+		return false
+	}
+	return s.crewLoaded && len(s.crewAgents) > 0
+}
+
+// crewFallbackHint devolve a mensagem mostrada no Input quando o picker não
+// está ativo (crew ausente OU sem agentes). Pré-condição: action == crew.run.
+func (s *formScreen) crewFallbackHint() string {
+	if !s.crewAddon.Installed {
+		return "Install with `shipyard crew install` to list agents. You can still type a name."
+	}
+	return "No crew agents found. Run `shipyard crew hire <name>` first, or type a name."
+}
+
 func (s *formScreen) renderCurrentStep() string {
 	switch s.focus {
 	case fieldPath:
@@ -273,14 +363,21 @@ func (s *formScreen) renderCurrentStep() string {
 		switch fairwayctl.ActionType(s.actionType.Selected().Key) {
 		case fairwayctl.ActionMessageSend:
 			s.actionTgt.SetHint("Optional logical target for the message.")
+			return s.actionTgt.View()
 		case fairwayctl.ActionHTTPForward:
 			s.actionTgt.SetHint("Destination URL starting with http:// or https://.")
+			return s.actionTgt.View()
 		case fairwayctl.ActionCrewRun:
-			s.actionTgt.SetHint("Crew agent name (see `shipyard crew list`).")
+			s.loadCrewAgentsOnce()
+			if s.crewPickerActive() {
+				return s.crewMenu.View()
+			}
+			s.actionTgt.SetHint(s.crewFallbackHint())
+			return s.actionTgt.View()
 		default:
 			s.actionTgt.SetHint("Shipyard object ID or target name.")
+			return s.actionTgt.View()
 		}
-		return s.actionTgt.View()
 	case fieldActionMeta:
 		if fairwayctl.ActionType(s.actionType.Selected().Key) == fairwayctl.ActionHTTPForward {
 			s.actionMeta.SetHint("Optional HTTP method override, for example POST.")
@@ -542,4 +639,36 @@ func (s *formScreen) snapshot() formState {
 		ActionMeta:   strings.TrimSpace(s.actionMeta.Value()),
 		Timeout:      strings.TrimSpace(s.timeout.Value()),
 	}
+}
+
+// Indireções para testes — substituídas em fairwaywiz_test.go.
+var (
+	listCrewAgents = func() ([]crewctl.AgentInfo, error) {
+		return crewctl.ListAgents("")
+	}
+	detectCrewAddon = func() addon.Info {
+		info, _ := addon.NewRegistry("").Detect(addon.KindCrew)
+		return info
+	}
+)
+
+// buildActionOptions clona actionOptions (declarado em shared.go) e desabilita
+// crew.run quando o crew addon não está instalado. allowCrewRun=true preserva
+// a opção habilitada no caso de edição de rota legada (rota existente já tinha
+// crew.run salvo); sem essa exceção, SetSelectedByKey cairia em fallback e
+// trocaria silenciosamente a seleção, perdendo dado do usuário.
+func buildActionOptions(crewInstalled, allowCrewRun bool) []components.MenuItem {
+	items := make([]components.MenuItem, 0, len(actionOptions))
+	for _, item := range actionOptions {
+		if item.Key == string(fairwayctl.ActionCrewRun) && !crewInstalled && !allowCrewRun {
+			disabled := item
+			disabled.Disabled = true
+			disabled.Badge = "install crew"
+			disabled.BadgeVariant = "muted"
+			items = append(items, disabled)
+			continue
+		}
+		items = append(items, item)
+	}
+	return items
 }

--- a/manifest
+++ b/manifest
@@ -1,3 +1,3 @@
-shipyard=1.3.3
+shipyard=1.3.4
 fairway=1.3.0
 crew=0.3.9


### PR DESCRIPTION
## Summary

- Substituído o `Input` de texto livre por `Menu` navegável de crew agents no step **Crew agent** (`fieldActionTarget`) quando `action = crew.run`
- Carga lazy via `crewctl.ListAgents` (uma única vez por instância); pré-seleção preservada ao editar rota existente com agente conhecido
- Fallback para `Input` com hint informativo quando crew não instalado (`shipyard crew install`) ou sem agentes (`shipyard crew hire`)

## Arquivos alterados

- `internal/ui/tui/fairwaywiz/form.go` — novos campos `crewMenu`, `crewAgents`, `crewAddon`, `crewLoaded` na struct; `loadCrewAgentsOnce`, `crewPickerActive`, `crewFallbackHint`; dispatch do menu em `Update`; render condicional em `renderCurrentStep`; resize em `WindowSizeMsg`; vars injetáveis `listCrewAgents`/`detectCrewAddon`; função pura `buildActionOptions`
- `internal/ui/tui/fairwaywiz/fairwaywiz_test.go` — 7 novos testes (4 sobre picker `ActionTarget` + 3 sobre `buildActionOptions`)

## Test plan

- `GOTOOLCHAIN=go1.26.2 go test ./internal/ui/tui/fairwaywiz/... -count=1` → PASS 37 tests (7 novos incluídos)
- `GOTOOLCHAIN=go1.26.2 go test ./... -count=1` → PASS todos os pacotes
- `GOTOOLCHAIN=go1.26.2 go build ./cmd/shipyard` → build verde

**Não validado:** fluxo manual do TUI no terminal (requer TTY real e daemons instalados). Lógica central coberta por testes unitários.

Closes #32