### PR TITLE
shipyard update reconcilia addons no mesmo run via subprocess

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -19,11 +22,26 @@ import (
 	"github.com/shipyard-auto/shipyard/internal/update"
 )
 
+// hasInstalledAddons devolve true quando o registry de addons lista pelo
+// menos um addon com Installed=true. Variável package-level para permitir
+// override em testes.
+var hasInstalledAddons = defaultHasInstalledAddons
+
+// runAddonReconcileSubprocess executa o binário corrente com `update
+// --skip-core`, propagando stdout/stderr para o writer do pai. Variável
+// package-level para que testes substituam por uma fake — chamar exec.Cmd
+// real em teste exigiria fork bomb com TestHelperProcess pattern.
+var runAddonReconcileSubprocess = defaultRunAddonReconcileSubprocess
+
 func newUpdateCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:     "update",
-		Short:   "Update Shipyard to the latest release",
-		Long:    "Download the latest published Shipyard release for this platform and replace the current binary. If shipyard-fairway is installed, it is also updated.",
+	var skipCore bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update Shipyard to the latest release",
+		Long: `Download the latest published Shipyard release for this platform and replace
+the current binary. If shipyard-fairway or shipyard-crew is installed, the
+new binary is invoked to reconcile them in the same run.`,
 		Example: "shipyard update",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			executablePath, err := os.Executable()
@@ -37,6 +55,18 @@ func newUpdateCmd() *cobra.Command {
 			}
 
 			w := cmd.OutOrStdout()
+
+			// --skip-core: caminho do filho re-executado pelo pai após self-
+			// update. Pula o download do core (já foi feito pelo pai) e roda
+			// apenas a reconciliação dos addons no binário novo.
+			if skipCore {
+				ui.Printf(w, "%s\n", ui.SectionTitle("Reconciling addons"))
+				ui.Printf(w, "%s\n\n", ui.Muted("Running addon reconcilers from the freshly installed binary."))
+				if err := updateFairwayIfInstalled(cmd, w); err != nil {
+					return err
+				}
+				return updateCrewIfInstalled(cmd, w)
+			}
 
 			ui.Printf(w, "%s\n", ui.SectionTitle("Shipyard Update"))
 			ui.Printf(w, "%s\n\n", ui.Muted("Checking the latest release and refreshing your local binary."))
@@ -58,12 +88,24 @@ func newUpdateCmd() *cobra.Command {
 				ui.Printf(w, "%s\n", ui.Emphasis("Shipyard is already up to date."))
 			}
 
+			// Quando o binário foi substituído, delegamos a reconciliação ao
+			// novo binário via subprocess. Quando NÃO houve update (mesmo
+			// binário nas duas pontas), reconciliamos inline — mais barato e
+			// idêntico ao comportamento histórico.
+			if result.Updated && hasInstalledAddons() {
+				return runAddonReconcileSubprocess(cmd.Context(), executablePath, w)
+			}
+
 			if err := updateFairwayIfInstalled(cmd, w); err != nil {
 				return err
 			}
 			return updateCrewIfInstalled(cmd, w)
 		},
 	}
+
+	cmd.Flags().BoolVar(&skipCore, "skip-core", false, "Skip core update; only reconcile installed addons. Used internally by the parent process after a self-update.")
+
+	return cmd
 }
 
 func updateFairwayIfInstalled(cmd *cobra.Command, w interface{ Write([]byte) (int, error) }) error {
@@ -171,4 +213,37 @@ func buildCrewInstallerForUpdate(version string) (*crewctl.Installer, error) {
 		HTTPClient:  crewctl.DefaultHTTPClient(),
 		ReleaseBase: crewctl.DefaultReleaseBase,
 	}, nil
+}
+
+// defaultHasInstalledAddons reads the addon registry and returns true when
+// any addon is marked as installed. Returns false on any registry error —
+// the worst case is missing the subprocess delegation, which falls back to
+// the historical inline reconciliation.
+func defaultHasInstalledAddons() bool {
+	reg := addon.NewRegistry("")
+	file, err := reg.Load()
+	if err != nil || file == nil {
+		return false
+	}
+	for _, info := range file.Addons {
+		if info != nil && info.Installed {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultRunAddonReconcileSubprocess invokes the binary at binPath with
+// `update --skip-core`, wiring stdout/stderr back to the parent's writer.
+// The call blocks until the child exits; the child's exit code is propagated
+// as the error return.
+func defaultRunAddonReconcileSubprocess(ctx context.Context, binPath string, w io.Writer) error {
+	cmd := exec.CommandContext(ctx, binPath, "update", "--skip-core")
+	cmd.Stdout = w
+	cmd.Stderr = w
+	cmd.Stdin = nil
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("reconcile addons via new binary: %w", err)
+	}
+	return nil
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// isolateUpdateHome aponta $HOME para um diretório temporário antes do teste.
+// Necessário porque `updateFairwayIfInstalled` e `updateCrewIfInstalled`
+// resolvem caminhos sob ~/.shipyard e podem fazer HTTP real se detectarem
+// addons instalados no HOME do dev/CI. Tmpdir limpo garante that ambos no-op.
+func isolateUpdateHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+}
+
+// stubUpdateHooks substitui hasInstalledAddons e runAddonReconcileSubprocess
+// por doubles e restaura no t.Cleanup. Devolve ponteiro para o contador de
+// chamadas do subprocess para asserts.
+type updateHookStubs struct {
+	subprocessCalls *int
+}
+
+func stubUpdateHooks(t *testing.T, hasAddons bool, subprocessErr error) updateHookStubs {
+	t.Helper()
+	origHas := hasInstalledAddons
+	origRun := runAddonReconcileSubprocess
+
+	var calls int
+	hasInstalledAddons = func() bool { return hasAddons }
+	runAddonReconcileSubprocess = func(ctx context.Context, p string, w io.Writer) error {
+		calls++
+		return subprocessErr
+	}
+
+	t.Cleanup(func() {
+		hasInstalledAddons = origHas
+		runAddonReconcileSubprocess = origRun
+	})
+	return updateHookStubs{subprocessCalls: &calls}
+}
+
+func newUpdateCmdForTest(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd := newUpdateCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetContext(context.Background())
+	return cmd, &buf
+}
+
+// TestUpdate_skipCoreBranch_runsReconcilersOnly exercita o caminho do filho.
+// Não chama update.Service nem o registry; só roda os reconcilers de addon,
+// que são no-op em HOME limpo (sem fairway/crew detectado).
+func TestUpdate_skipCoreBranch_runsReconcilersOnly(t *testing.T) {
+	isolateUpdateHome(t)
+	stubUpdateHooks(t, false, nil)
+
+	cmd, buf := newUpdateCmdForTest(t)
+	cmd.SetArgs([]string{"--skip-core"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute --skip-core: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Reconciling addons") {
+		t.Errorf("missing reconcile header on --skip-core branch:\n%s", out)
+	}
+	if strings.Contains(out, "Shipyard Update") {
+		t.Errorf("--skip-core must NOT print the core-update header:\n%s", out)
+	}
+}
+
+// TestUpdate_skipCoreBranch_doesNotCallSubprocess garante que o filho nunca
+// re-spawna a si mesmo (recursão infinita).
+func TestUpdate_skipCoreBranch_doesNotCallSubprocess(t *testing.T) {
+	isolateUpdateHome(t)
+	stubs := stubUpdateHooks(t, true, nil)
+
+	cmd, _ := newUpdateCmdForTest(t)
+	cmd.SetArgs([]string{"--skip-core"})
+	_ = cmd.Execute()
+
+	if *stubs.subprocessCalls != 0 {
+		t.Errorf("--skip-core branch must NOT spawn the subprocess (would recurse), got %d calls", *stubs.subprocessCalls)
+	}
+}
+
+// Os 3 testes seguintes validam a condição de delegação do caminho pai sem
+// dirigir o update.Service real (que faria HTTP). A função-espelho
+// shouldDelegateToSubprocess **deve** refletir literalmente a condição em
+// RunE: `result.Updated && hasInstalledAddons()`. Se o RunE mudar essa
+// condição, este helper PRECISA mudar junto — está no mesmo arquivo
+// propositadamente para manter o acoplamento visível.
+
+func shouldDelegateToSubprocess(updated bool) bool {
+	return updated && hasInstalledAddons()
+}
+
+func TestShouldDelegate_updatedAndAddonsInstalled_delegates(t *testing.T) {
+	stubUpdateHooks(t, true, nil)
+	if !shouldDelegateToSubprocess(true) {
+		t.Errorf("must delegate when core was updated AND addons are present")
+	}
+}
+
+func TestShouldDelegate_updatedNoAddons_doesNotDelegate(t *testing.T) {
+	stubUpdateHooks(t, false, nil)
+	if shouldDelegateToSubprocess(true) {
+		t.Errorf("must NOT delegate when no addons are installed")
+	}
+}
+
+func TestShouldDelegate_notUpdated_doesNotDelegate(t *testing.T) {
+	stubUpdateHooks(t, true, nil)
+	if shouldDelegateToSubprocess(false) {
+		t.Errorf("must NOT delegate when core was not updated (same binary both ends)")
+	}
+}


### PR DESCRIPTION
## Summary

- Added `--skip-core` flag to `shipyard update`; the child process path runs only addon reconcilers (`updateFairwayIfInstalled` + `updateCrewIfInstalled`) from the freshly installed binary.
- Added package-level variables `hasInstalledAddons` and `runAddonReconcileSubprocess` (pointing to their `default*` implementations) to make the delegation logic testable without HTTP or fork-bomb patterns.
- After a successful core self-update, the parent process spawns `<new-binary> update --skip-core` only when at least one addon is installed; inline reconciliation (historical behaviour) is preserved when no update occurred.

## Arquivos alterados

- `internal/cli/update.go` — added `context`/`io`/`os/exec` imports, two injectable package-level vars, new `newUpdateCmd` with `--skip-core` bifurcation, `defaultHasInstalledAddons` and `defaultRunAddonReconcileSubprocess` appended after `buildCrewInstallerForUpdate`.
- `internal/cli/update_test.go` — new file with 5 tests: 2 for the `--skip-core` child path, 3 for the delegation condition guard (`shouldDelegateToSubprocess`).

## Test plan

- `GOTOOLCHAIN=go1.26.2 go build ./cmd/shipyard` → BUILD OK
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli/... -count=1 -run "Update|ShouldDelegate|Reconcile" -v` → PASS 5 packages (TestUpdate_skipCoreBranch_runsReconcilersOnly, TestUpdate_skipCoreBranch_doesNotCallSubprocess, TestShouldDelegate_updatedAndAddonsInstalled_delegates, TestShouldDelegate_updatedNoAddons_doesNotDelegate, TestShouldDelegate_notUpdated_doesNotDelegate)
- `GOTOOLCHAIN=go1.26.2 go test ./... -count=1` → all packages pass; `TestRoot_snapshotScreens` in `internal/ui/tui/fairwaywiz` fails — confirmed pre-existing on `main` before this branch (verified via `git stash`).
- Não validei: smoke manual com release nova real (nenhum novo release disponível no ambiente de CI).

Closes #34