### PR TITLE
Toggle async/sync no wizard shipyard fairway config

### DIFF
--- a/internal/ui/tui/fairwaywiz/fairwaywiz_test.go
+++ b/internal/ui/tui/fairwaywiz/fairwaywiz_test.go
@@ -425,7 +425,7 @@ func TestRouteFromFormState_invalidTimeout(t *testing.T) {
 
 func TestForm_visibleFields_changeWithSelections(t *testing.T) {
 	screen := newFormScreen(theme.New(), &fakeClient{}, nil).(*formScreen)
-	if got := screen.visibleFields(); len(got) != 7 {
+	if got := screen.visibleFields(); len(got) != 8 {
 		t.Fatalf("unexpected default field count: %d", len(got))
 	}
 
@@ -875,5 +875,54 @@ func TestFormScreen_actionMenu_legacyEditKeepsCrewRunEnabled(t *testing.T) {
 
 	if strings.Contains(view, "install crew") {
 		t.Errorf("editing a legacy crew.run route must keep the option enabled (no badge), even when crew is absent.\nrendered view:\n%s", view)
+	}
+}
+
+// ====== X-04 async toggle tests ======
+
+func TestFormScreen_async_defaultsToSync(t *testing.T) {
+	scr := newFormScreen(theme.New(), nil, nil).(*formScreen)
+	if got := scr.async.Selected().Key; got != "sync" {
+		t.Errorf("new route must default to sync; got %q", got)
+	}
+	state := scr.snapshot()
+	if state.Async {
+		t.Errorf("snapshot of new route must have Async=false; got true")
+	}
+}
+
+func TestFormScreen_async_preservesAsyncRouteOnEdit(t *testing.T) {
+	original := &fairwayctl.Route{
+		Path:   "/hooks/async-route",
+		Auth:   fairwayctl.Auth{Type: fairwayctl.AuthLocalOnly},
+		Action: fairwayctl.Action{Type: fairwayctl.ActionCronRun, Target: "abc"},
+		Async:  true,
+	}
+	scr := newFormScreen(theme.New(), nil, original).(*formScreen)
+
+	if got := scr.async.Selected().Key; got != "async" {
+		t.Errorf("editing async route must preselect async; got %q", got)
+	}
+	state := scr.snapshot()
+	if !state.Async {
+		t.Errorf("snapshot must preserve Async=true on edit; got false")
+	}
+}
+
+func TestFormScreen_async_snapshotReflectsToggle(t *testing.T) {
+	scr := newFormScreen(theme.New(), nil, nil).(*formScreen)
+	// Default is sync; flip to async.
+	scr.async.SetSelectedByKey("async")
+
+	state := scr.snapshot()
+	if !state.Async {
+		t.Errorf("snapshot must reflect manual toggle to async; got Async=false")
+	}
+
+	// And back.
+	scr.async.SetSelectedByKey("sync")
+	state = scr.snapshot()
+	if state.Async {
+		t.Errorf("snapshot must reflect manual toggle back to sync; got Async=true")
 	}
 }

--- a/internal/ui/tui/fairwaywiz/form.go
+++ b/internal/ui/tui/fairwaywiz/form.go
@@ -24,6 +24,7 @@ const (
 	fieldActionTarget
 	fieldActionMeta
 	fieldTimeout
+	fieldAsync
 	fieldSubmit
 )
 
@@ -44,6 +45,7 @@ type formScreen struct {
 	crewLoaded bool                // garante que carregamos só uma vez
 	actionMeta components.Input
 	timeout    components.Input
+	async      components.Menu
 	focus      formField
 	err        string
 	submitting bool
@@ -71,6 +73,12 @@ func newFormScreen(th theme.Theme, client FairwayClient, route *fairwayctl.Route
 	authMenu.SetSelectedByKey(state.AuthType)
 	actionMenu := components.NewMenu(th, buildActionOptions(crewAddon.Installed, allowCrewRun))
 	actionMenu.SetSelectedByKey(state.ActionType)
+	asyncMenu := components.NewMenu(th, asyncOptions)
+	asyncKey := "sync"
+	if state.Async {
+		asyncKey = "async"
+	}
+	asyncMenu.SetSelectedByKey(asyncKey)
 
 	authSecret.SetValue(state.AuthSecret)
 	authLookup.SetValue(state.AuthLookup)
@@ -98,6 +106,7 @@ func newFormScreen(th theme.Theme, client FairwayClient, route *fairwayctl.Route
 		crewAddon:  crewAddon,
 		actionMeta: actionMeta,
 		timeout:    timeout,
+		async:      asyncMenu,
 	}
 	if route != nil {
 		screen.mode = modeEdit
@@ -146,6 +155,8 @@ func (s *formScreen) Update(msg tea.Msg) (Screen, tea.Cmd) {
 		s.authType = menu
 		action := s.actionType.SetWidth(msg.Width)
 		s.actionType = action
+		asyncSized := s.async.SetWidth(msg.Width)
+		s.async = asyncSized
 		if s.crewLoaded && len(s.crewAgents) > 0 {
 			crewSized := s.crewMenu.SetWidth(msg.Width)
 			s.crewMenu = crewSized
@@ -233,6 +244,15 @@ func (s *formScreen) Update(msg tea.Msg) (Screen, tea.Cmd) {
 	case fieldTimeout:
 		cmd, _ := s.timeout.Update(msg)
 		return s, cmd
+	case fieldAsync:
+		menu, cmd := s.async.Update(msg)
+		s.async = menu
+		if cmd != nil {
+			s.err = ""
+			s.focus = s.nextField()
+			s.syncFocus()
+		}
+		return s, nil
 	case fieldSubmit:
 		if key, ok := msg.(tea.KeyMsg); ok && key.String() == "enter" {
 			route, err := routeFromFormState(s.snapshot())
@@ -388,6 +408,13 @@ func (s *formScreen) renderCurrentStep() string {
 		return s.actionMeta.View()
 	case fieldTimeout:
 		return s.timeout.View()
+	case fieldAsync:
+		if fairwayctl.ActionType(s.actionType.Selected().Key) == fairwayctl.ActionHTTPForward {
+			return s.async.View() + "\n\n" + s.theme.RenderHint(
+				"Note: http.forward routes cannot be async — selecting Async will fail at submit.",
+			)
+		}
+		return s.async.View()
 	case fieldSubmit:
 		return s.submitPanel()
 	}
@@ -427,6 +454,8 @@ func (s *formScreen) stepLabel(f formField) string {
 		return "Provider"
 	case fieldTimeout:
 		return "Timeout"
+	case fieldAsync:
+		return "Mode"
 	case fieldSubmit:
 		return "Review & confirm"
 	}
@@ -471,6 +500,8 @@ func (s *formScreen) fieldValue(f formField) string {
 		return strings.TrimSpace(s.actionMeta.Value())
 	case fieldTimeout:
 		return strings.TrimSpace(s.timeout.Value())
+	case fieldAsync:
+		return s.async.Selected().Title
 	}
 	return ""
 }
@@ -625,7 +656,7 @@ func (s *formScreen) visibleFields() []formField {
 	case fairwayctl.ActionHTTPForward:
 		fields = append(fields, fieldActionTarget, fieldActionMeta)
 	}
-	fields = append(fields, fieldTimeout, fieldSubmit)
+	fields = append(fields, fieldTimeout, fieldAsync, fieldSubmit)
 	return fields
 }
 
@@ -639,6 +670,7 @@ func (s *formScreen) snapshot() formState {
 		ActionTarget: strings.TrimSpace(s.actionTgt.Value()),
 		ActionMeta:   strings.TrimSpace(s.actionMeta.Value()),
 		Timeout:      strings.TrimSpace(s.timeout.Value()),
+		Async:        s.async.Selected().Key == "async",
 	}
 }
 

--- a/internal/ui/tui/fairwaywiz/shared.go
+++ b/internal/ui/tui/fairwaywiz/shared.go
@@ -68,6 +68,11 @@ var (
 	}
 )
 
+var asyncOptions = []components.MenuItem{
+	{Title: "Sync", Description: "Wait for the action to finish and return its result.", Key: "sync"},
+	{Title: "Async", Description: "Respond 202 Accepted immediately and run the action detached.", Key: "async"},
+}
+
 func loadRoutesCmd(client FairwayClient) tea.Cmd {
 	return func() tea.Msg {
 		routes, err := client.RouteList(context.Background())
@@ -265,6 +270,8 @@ func routeFromFormState(s formState) (fairwayctl.Route, error) {
 		route.Timeout = timeout
 	}
 
+	route.Async = s.Async
+
 	if err := route.Validate(); err != nil {
 		return fairwayctl.Route{}, err
 	}
@@ -280,6 +287,7 @@ type formState struct {
 	ActionTarget string
 	ActionMeta   string
 	Timeout      string
+	Async        bool
 }
 
 func formStateFromRoute(route *fairwayctl.Route) formState {
@@ -321,5 +329,6 @@ func formStateFromRoute(route *fairwayctl.Route) formState {
 	if route.Timeout == 0 {
 		state.Timeout = ""
 	}
+	state.Async = route.Async
 	return state
 }

--- a/manifest
+++ b/manifest
@@ -1,3 +1,3 @@
-shipyard=1.3.4
+shipyard=1.3.5
 fairway=1.3.0
 crew=0.3.9


### PR DESCRIPTION
## Summary
- Adiciona step **Mode (sync/async)** ao wizard `shipyard fairway config`, posicionado após o step Timeout
- Inicializa o menu com **Sync** como default em criação; preseleciona **Async** ao editar rota existente com `Async=true`
- Exibe hint inline no step Mode quando action=http.forward, informando que o daemon rejeitará async nesse caso

## Arquivos alterados
- `internal/ui/tui/fairwaywiz/shared.go` — novo `var asyncOptions`; campo `Async bool` em `formState`; popular em `formStateFromRoute`; ler em `routeFromFormState`
- `internal/ui/tui/fairwaywiz/form.go` — novo `fieldAsync` no enum; campo `async components.Menu` em `formScreen`; inicialização, resize, despacho, render, stepLabel, fieldValue, visibleFields e snapshot atualizados
- `internal/ui/tui/fairwaywiz/fairwaywiz_test.go` — 3 novos testes X-04 (default sync, preserva async em edição, snapshot reflete toggle); atualização de contagem em `TestForm_visibleFields_changeWithSelections` (7→8)

## Test plan
- `GOTOOLCHAIN=go1.26.2 go build ./cmd/shipyard` → `BUILD OK`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/ui/tui/fairwaywiz/... -count=1` → `ok github.com/shipyard-auto/shipyard/internal/ui/tui/fairwaywiz 0.278s` (todos os testes passando, incluindo os 3 novos)
- `GOTOOLCHAIN=go1.26.2 go test ./... -count=1` → todos os 38 pacotes com testes: PASS

Não validei: cenários manuais de TUI (criar/editar rota async e verificar `shipyard fairway route list`) — requerem daemon rodando e TTY real.

Closes #36